### PR TITLE
Allow application/json script tag type

### DIFF
--- a/lib/better_html/test_helper/safe_erb_tester.rb
+++ b/lib/better_html/test_helper/safe_erb_tester.rb
@@ -71,7 +71,7 @@ EOF
       class Tester
         attr_reader :errors
 
-        VALID_JAVASCRIPT_TAG_TYPES = ['text/javascript', 'text/template', 'text/html']
+        VALID_JAVASCRIPT_TAG_TYPES = ['text/javascript', 'text/template', 'text/html', 'application/json']
 
         def initialize(data, **options)
           @data = data


### PR DESCRIPTION
This PR allows use of the `<script type="application/json>` tag.