### PR TITLE
Remove comments so they are parsed as normal statements

### DIFF
--- a/lib/better_html/node_iterator/html_erb.rb
+++ b/lib/better_html/node_iterator/html_erb.rb
@@ -9,7 +9,7 @@ module BetterHtml
       attr_reader :tokens
       attr_reader :parser
 
-      REGEXP_WITHOUT_TRIM = /<%(={1,2}|-|\#|%)?(.*?)(?:[-=])?()?%>([ \t]*\r?\n)?/m
+      REGEXP_WITHOUT_TRIM = /<%(={1,2}|-|%)?(.*?)(?:[-=])?()?%>([ \t]*\r?\n)?/m
 
       def initialize(document)
         @parser = HtmlTokenizer::Parser.new

--- a/test/better_html/node_iterator/html_erb_test.rb
+++ b/test/better_html/node_iterator/html_erb_test.rb
@@ -83,6 +83,23 @@ module BetterHtml
         assert_attributes ({ line: 4 }), scanner.tokens[3].location
       end
 
+      test "line counts with comments" do
+        scanner = BetterHtml::NodeIterator::HtmlErb.new("before\n<%# BO$$ Mode %>\nafter")
+        assert_equal 4, scanner.tokens.size
+
+        assert_attributes ({ type: :text, text: "before\n" }), scanner.tokens[0]
+        assert_attributes ({ line: 1 }), scanner.tokens[0].location
+
+        assert_attributes ({ type: :stmt, text: "<%# BO$$ Mode %>" }), scanner.tokens[1]
+        assert_attributes ({ line: 2 }), scanner.tokens[1].location
+
+        assert_attributes ({ type: :text, text: "\n" }), scanner.tokens[2]
+        assert_attributes ({ line: 2 }), scanner.tokens[2].location
+
+        assert_attributes ({ type: :text, text: "after" }), scanner.tokens[3]
+        assert_attributes ({ line: 3 }), scanner.tokens[3].location
+      end
+
       private
 
       def assert_attributes(attributes, token)


### PR DESCRIPTION
An extra newline is inserted whenever an ERB comment is present; this removes `#` from the default regexp so that comments are simply parsed as normal statements.