### PR TITLE
Allow for custom configuration for each object instance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       activesupport (>= 4.0)
       erubi (~> 1.4)
       parser (>= 2.4)
+      smart_properties
 
 GEM
   remote: https://rubygems.org/
@@ -53,6 +54,7 @@ GEM
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     rake (11.1.2)
+    smart_properties (1.13.0)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -70,4 +72,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -12,6 +12,55 @@ gem "better_html", git: "https://github.com/Shopify/better-html.git"
 gem "html_tokenizer", git: "https://github.com/EiNSTeiN-/html_tokenizer.git"
 ```
 
+## Configuration
+
+A global configuration for the app is stored at `BetterHtml.config`. The default
+configuration can be changed like this:
+
+```ruby
+# config/initializers/better_html.rb
+BetterHtml.configure do |config|
+  config.allow_single_quoted_attributes = false
+end
+```
+
+or if you prefer storing the config elsewhere, in a yml file for example:
+
+```ruby
+# config/initializers/better_html.rb
+BetterHtml.config = BetterHtml::Config.new(YAML.load(File.read('/path/to/.better-html.yml')))
+```
+
+Available configuration options are:
+
+* `partial_tag_name_pattern`: Regex to validate `foo` in `<foo>`. Defaults to `/\A[a-z0-9\-\:]+\z/`.
+* `partial_attribute_name_pattern`: Regex to validate `bar` in `<foo bar=1>`. Defaults to `/\A[a-zA-Z0-9\-\:]+\z/`.
+* `allow_single_quoted_attributes`: When true, `<foo bar='1'>` is valid syntax. Defaults to `true`.
+* `allow_unquoted_attributes`: When true, `<foo bar=1>` is valid syntax. Defaults to `false`.
+* `javascript_safe_methods`: List of methods that return javascript-safe strings. This list is used
+  by `SafeErbTester` when determining whether ruby interpolation is safe for a given attribute.
+  Defaults to `['to_json']`.
+* `lodash_safe_javascript_expression`: Same as `javascript_safe_methods`, but for lodash templates.
+  Defaults to `[/\AJSON\.stringify\(/]`.
+* `javascript_attribute_names`: List of all attribute names that contain javascript code. This list is used
+  by `SafeErbTester` when determining whether or not a given attribute value will be eval'ed as javascript.
+  Defaults to `[/\Aon/i]` (matches `onclick` for example).
+* `template_exclusion_filter`: This is called when determining whether to apply runtime checks on a `.erb` template.
+  When this `Proc` returns false, no safety checks are applied and parsing is done using the default Rails erubi engine.
+  For example, to exclude erb templates provided by libraries, use: `Proc.new { |filename| !filename.start_with?(Rails.root.to_s) }`.
+  Defaults to `nil` (all html.erb templates are parsed).
+
+By default, only files named `.html.erb` are parsed at runtime using BetterHtml's erubi implementation.
+To change this behavior and parse other file types, assign the erubi implementation into `BetterHtml::BetterErb.content_types` like this:
+
+```ruby
+# config/initializers/better_html.rb
+impl = BetterHtml::BetterErb.content_types['html.erb']
+BetterHtml::BetterErb.content_types['htm.erb'] = impl
+BetterHtml::BetterErb.content_types['atom.erb'] = impl
+BetterHtml::BetterErb.content_types['html+variant.erb'] = impl
+```
+
 ## Syntax restriction
 
 In order to apply effective runtime checks, it is necessary to enforce the

--- a/better_html.gemspec
+++ b/better_html.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 4.0'
   s.add_dependency 'actionview', '>= 4.0'
   s.add_dependency 'parser', '>= 2.4'
+  s.add_dependency 'smart_properties'
 
   s.add_development_dependency 'rake', '~> 0'
 end

--- a/lib/better_html.rb
+++ b/lib/better_html.rb
@@ -3,49 +3,17 @@ require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/class/attribute_accessors'
 
 module BetterHtml
-  class Config
-    # regex to validate "foo" in "<foo>"
-    cattr_accessor :partial_tag_name_pattern
-    self.partial_tag_name_pattern = /\A[a-z0-9\-\:]+\z/
-
-    # regex to validate "bar" in "<foo bar=1>"
-    cattr_accessor :partial_attribute_name_pattern
-    self.partial_attribute_name_pattern = /\A[a-zA-Z0-9\-\:]+\z/
-
-    # true if "<foo bar='1'>" is valid syntax
-    cattr_accessor :allow_single_quoted_attributes
-    self.allow_single_quoted_attributes = false
-
-    # true if "<foo bar=1>" is valid syntax
-    cattr_accessor :allow_unquoted_attributes
-    self.allow_unquoted_attributes = false
-
-    # all methods that return "javascript-safe" strings
-    cattr_accessor :javascript_safe_methods
-    self.javascript_safe_methods = ['to_json']
-
-    # name of all html attributes that may contain javascript
-    cattr_accessor :javascript_attribute_names
-    self.javascript_attribute_names = [/\Aon/i]
-
-    cattr_accessor :template_exclusion_filter_block
-
-    def self.template_exclusion_filter(&block)
-      self.template_exclusion_filter_block = block
-    end
-
-    cattr_accessor :lodash_safe_javascript_expression
-    self.lodash_safe_javascript_expression = [/\AJSON\.stringify\(/]
+  def self.configure
+    yield config if block_given?
   end
 
   def self.config
     @config ||= Config.new
-    yield @config if block_given?
-    @config
   end
 end
 
 require 'better_html/version'
+require 'better_html/config'
 require 'better_html/helpers'
 require 'better_html/errors'
 require 'better_html/html_attributes'

--- a/lib/better_html.rb
+++ b/lib/better_html.rb
@@ -10,6 +10,10 @@ module BetterHtml
   def self.config
     @config ||= Config.new
   end
+
+  def self.config=(new_config)
+    @config = new_config
+  end
 end
 
 require 'better_html/version'

--- a/lib/better_html/better_erb.rb
+++ b/lib/better_html/better_erb.rb
@@ -52,7 +52,7 @@ class BetterHtml::BetterErb
       # Always make sure we return a String in the default_internal
       erb.encode!
 
-      excluded_template = !!BetterHtml::Config.template_exclusion_filter_block&.call(template.identifier)
+      excluded_template = !!BetterHtml.config.template_exclusion_filter_block&.call(template.identifier)
       klass = BetterHtml::BetterErb.content_types[exts] unless excluded_template
       klass ||= self.class.erb_implementation
 

--- a/lib/better_html/better_erb/runtime_checks.rb
+++ b/lib/better_html/better_erb/runtime_checks.rb
@@ -3,9 +3,10 @@ require 'action_view'
 
 class BetterHtml::BetterErb
   module RuntimeChecks
-    def initialize(*)
+    def initialize(erb, config: BetterHtml.config, **options)
       @parser = HtmlTokenizer::Parser.new
-      super
+      @config = config
+      super(erb, **options)
     end
 
     def validate!
@@ -112,26 +113,26 @@ class BetterHtml::BetterErb
     def check_tag_name(type, start, stop, line, column)
       text = @parser.extract(start, stop)
       return if text.upcase == "!DOCTYPE"
-      return if BetterHtml.config.partial_tag_name_pattern === text
+      return if @config.partial_tag_name_pattern === text
 
       s = "Invalid tag name #{text.inspect} does not match "\
-        "regular expression #{BetterHtml.config.partial_tag_name_pattern.inspect}\n"
+        "regular expression #{@config.partial_tag_name_pattern.inspect}\n"
       s << build_location(line, column, text.size)
       raise BetterHtml::HtmlError, s
     end
 
     def check_attribute_name(type, start, stop, line, column)
       text = @parser.extract(start, stop)
-      return if BetterHtml.config.partial_attribute_name_pattern === text
+      return if @config.partial_attribute_name_pattern === text
 
       s = "Invalid attribute name #{text.inspect} does not match "\
-        "regular expression #{BetterHtml.config.partial_attribute_name_pattern.inspect}\n"
+        "regular expression #{@config.partial_attribute_name_pattern.inspect}\n"
       s << build_location(line, column, text.size)
       raise BetterHtml::HtmlError, s
     end
 
     def check_quoted_value(type, start, stop, line, column)
-      return if BetterHtml.config.allow_single_quoted_attributes
+      return if @config.allow_single_quoted_attributes
       text = @parser.extract(start, stop)
       return if text == '"'
 
@@ -141,7 +142,7 @@ class BetterHtml::BetterErb
     end
 
     def check_unquoted_value(type, start, stop, line, column)
-      return if BetterHtml.config.allow_unquoted_attributes
+      return if @config.allow_unquoted_attributes
       s = "Unquoted attribute values are not allowed\n"
       s << build_location(line, column, stop-start)
       raise BetterHtml::HtmlError, s

--- a/lib/better_html/config.rb
+++ b/lib/better_html/config.rb
@@ -1,0 +1,33 @@
+require 'smart_properties'
+
+module BetterHtml
+  class Config
+    include SmartProperties
+
+    # regex to validate "foo" in "<foo>"
+    property :partial_tag_name_pattern, default: /\A[a-z0-9\-\:]+\z/
+
+    # regex to validate "bar" in "<foo bar=1>"
+    property :partial_attribute_name_pattern, default: /\A[a-zA-Z0-9\-\:]+\z/
+
+    # true if "<foo bar='1'>" is valid syntax
+    property :allow_single_quoted_attributes, default: true
+
+    # true if "<foo bar=1>" is valid syntax
+    property :allow_unquoted_attributes, default: false
+
+    # all methods that return "javascript-safe" strings
+    property :javascript_safe_methods, default: ['to_json']
+
+    # name of all html attributes that may contain javascript
+    property :javascript_attribute_names, default: [/\Aon/i]
+
+    # block that can be used to selectively enable which templates to parse.
+    property :template_exclusion_filter_block
+    def template_exclusion_filter(&block)
+      self.template_exclusion_filter_block = block
+    end
+
+    property :lodash_safe_javascript_expression, default: [/\AJSON\.stringify\(/]
+  end
+end

--- a/lib/better_html/config.rb
+++ b/lib/better_html/config.rb
@@ -4,30 +4,13 @@ module BetterHtml
   class Config
     include SmartProperties
 
-    # regex to validate "foo" in "<foo>"
     property :partial_tag_name_pattern, default: /\A[a-z0-9\-\:]+\z/
-
-    # regex to validate "bar" in "<foo bar=1>"
     property :partial_attribute_name_pattern, default: /\A[a-zA-Z0-9\-\:]+\z/
-
-    # true if "<foo bar='1'>" is valid syntax
     property :allow_single_quoted_attributes, default: true
-
-    # true if "<foo bar=1>" is valid syntax
     property :allow_unquoted_attributes, default: false
-
-    # all methods that return "javascript-safe" strings
     property :javascript_safe_methods, default: ['to_json']
-
-    # name of all html attributes that may contain javascript
     property :javascript_attribute_names, default: [/\Aon/i]
-
-    # block that can be used to selectively enable which templates to parse.
-    property :template_exclusion_filter_block
-    def template_exclusion_filter(&block)
-      self.template_exclusion_filter_block = block
-    end
-
+    property :template_exclusion_filter
     property :lodash_safe_javascript_expression, default: [/\AJSON\.stringify\(/]
   end
 end

--- a/lib/better_html/test_helper/safe_erb_tester.rb
+++ b/lib/better_html/test_helper/safe_erb_tester.rb
@@ -52,8 +52,9 @@ EOF
 
         VALID_JAVASCRIPT_TAG_TYPES = ['text/javascript', 'text/template', 'text/html']
 
-        def initialize(data, **options)
+        def initialize(data, config: BetterHtml.config, **options)
           @data = data
+          @config = config
           @errors = Errors.new
           @options = options.present? ? options.dup : {}
           @options[:template_language] ||= :html
@@ -228,11 +229,11 @@ EOF
         end
 
         def javascript_attribute_name?(name)
-          BetterHtml.config.javascript_attribute_names.any?{ |other| other === name.to_s }
+          @config.javascript_attribute_names.any?{ |other| other === name.to_s }
         end
 
         def javascript_safe_method?(name)
-          BetterHtml.config.javascript_safe_methods.include?(name.to_s)
+          @config.javascript_safe_methods.include?(name.to_s)
         end
 
         def validate_script_tag_content(node)

--- a/lib/better_html/test_helper/safe_lodash_tester.rb
+++ b/lib/better_html/test_helper/safe_lodash_tester.rb
@@ -25,8 +25,8 @@ Never use <script> tags inside lodash template.
 -----------
 EOF
 
-      def assert_lodash_safety(data)
-        tester = Tester.new(data)
+      def assert_lodash_safety(data, **options)
+        tester = Tester.new(data, **options)
 
         message = ""
         tester.errors.each do |error|
@@ -47,8 +47,9 @@ EOF
       class Tester
         attr_reader :errors
 
-        def initialize(data)
+        def initialize(data, config: BetterHtml.config)
           @data = data
+          @config = config
           @errors = Errors.new
           @nodes = BetterHtml::NodeIterator.new(data, template_language: :lodash)
           validate!
@@ -109,11 +110,11 @@ EOF
         end
 
         def javascript_attribute_name?(name)
-          BetterHtml.config.javascript_attribute_names.any?{ |other| other === name }
+          @config.javascript_attribute_names.any?{ |other| other === name }
         end
 
         def lodash_safe_javascript_expression?(code)
-          BetterHtml.config.lodash_safe_javascript_expression.any?{ |other| other === code }
+          @config.lodash_safe_javascript_expression.any?{ |other| other === code }
         end
 
         def validate_no_statements(node)

--- a/test/better_html/test_helper/safe_erb_tester_test.rb
+++ b/test/better_html/test_helper/safe_erb_tester_test.rb
@@ -5,12 +5,10 @@ module BetterHtml
   module TestHelper
     class SafeErbTesterTest < ActiveSupport::TestCase
       setup do
-        BetterHtml.config
-          .stubs(:javascript_safe_methods)
-          .returns(['j', 'escape_javascript', 'to_json'])
-        BetterHtml.config
-          .stubs(:javascript_attribute_names)
-          .returns([/\Aon/i, 'data-eval'])
+        @config = BetterHtml::Config.new(
+          javascript_safe_methods: ['j', 'escape_javascript', 'to_json'],
+          javascript_attribute_names: [/\Aon/i, 'data-eval'],
+        )
       end
 
       test "string without interpolation is safe" do
@@ -400,7 +398,7 @@ module BetterHtml
 
       private
       def parse(data, template_language: :html)
-        SafeErbTester::Tester.new(data, template_language: template_language)
+        SafeErbTester::Tester.new(data, config: @config, template_language: template_language)
       end
     end
   end


### PR DESCRIPTION
This should enable use cases such as loading the config from a yml file so policial.io can use the proper config for each repo instead of using its own static config.

FYI @volmer 