### PR TITLE
Change how Location "stop" works

### DIFF
--- a/lib/better_html/node_iterator/html_erb.rb
+++ b/lib/better_html/node_iterator/html_erb.rb
@@ -25,7 +25,7 @@ module BetterHtml
       def add_code(code)
         text = "<%#{code}%>"
         start = @parser.document_length
-        stop = start + text.size
+        stop = start + text.size - 1
         @tokens << Token.new(
           type: :stmt,
           code: code,
@@ -39,7 +39,7 @@ module BetterHtml
       def add_expression(indicator, code)
         text = "<%#{indicator}#{code}%>"
         start = @parser.document_length
-        stop = start + text.size
+        stop = start + text.size - 1
         @tokens << Token.new(
           type: indicator == '=' ? :expr_literal : :expr_escaped,
           code: code,
@@ -61,7 +61,7 @@ module BetterHtml
         @tokens << Token.new(
           type: type,
           text: @parser.document[start...stop],
-          location: Location.new(@document, start, stop, line, column),
+          location: Location.new(@document, start, stop - 1, line, column),
           **(extra_attributes || {})
         )
       end

--- a/lib/better_html/node_iterator/html_lodash.rb
+++ b/lib/better_html/node_iterator/html_lodash.rb
@@ -61,7 +61,7 @@ module BetterHtml
 
       def add_text(text)
         @parser.parse(text) do |type, start, stop, line, column|
-          add_token(type, @parser.document[start...stop], start: start, stop: stop, line: line, column: column)
+          add_token(type, @parser.document[start...stop], start: start, stop: stop - 1, line: line, column: column)
         end
       end
 
@@ -82,7 +82,7 @@ module BetterHtml
 
       def add_token(type, text, code: nil, start: nil, stop: nil, line: nil, column: nil)
         start ||= @parser.document_length
-        stop ||= start + text.size
+        stop ||= start + text.size - 1
         extra_attributes = if type == :tag_end
           {
             self_closing: @parser.self_closing_tag?

--- a/lib/better_html/node_iterator/javascript_erb.rb
+++ b/lib/better_html/node_iterator/javascript_erb.rb
@@ -15,7 +15,7 @@ module BetterHtml
       end
 
       def add_text(text)
-        add_token(:text, text)
+        add_token(:text, text) if text.present?
         append(text)
       end
 
@@ -34,16 +34,14 @@ module BetterHtml
       private
 
       def add_token(type, text, code = nil)
+        raise ArgumentError, "empty #{type} token" if text.size == 0
         start = @parsed_document.size
-        stop = start + text.size
-        lines = @parsed_document.split("\n", -1)
-        line = lines.empty? ? 1 : lines.size
-        column = lines.empty? ? 0 : lines.last.size
+        stop = start + text.size - 1
         @tokens << Token.new(
           type: type,
           text: text,
           code: code,
-          location: Location.new(@source, start, stop, line, column)
+          location: Location.new(@source, start, stop)
         )
       end
 

--- a/lib/better_html/node_iterator/location.rb
+++ b/lib/better_html/node_iterator/location.rb
@@ -4,6 +4,10 @@ module BetterHtml
       attr_accessor :start, :stop
 
       def initialize(document, start, stop, line = nil, column = nil)
+        raise ArgumentError, "start location #{start} is out of range for document of size #{document.size}" if start > document.size
+        raise ArgumentError, "stop location #{stop} is out of range for document of size #{document.size}" if stop > document.size
+        raise ArgumentError, "end of range must be greater than start of range (#{stop} < #{start})" if stop < start
+
         @document = document
         @start = start
         @stop = stop
@@ -12,7 +16,7 @@ module BetterHtml
       end
 
       def range
-        Range.new(start, stop-1)
+        Range.new(start, stop)
       end
 
       def source
@@ -31,7 +35,7 @@ module BetterHtml
         line_content = extract_line(line: line)
         spaces = line_content.scan(/\A\s*/).first
         column_without_spaces = [column - spaces.length, 0].max
-        underscore_length = [[stop - start, line_content.length - column_without_spaces].min, 1].max
+        underscore_length = [[stop - start + 1, line_content.length - column_without_spaces].min, 1].max
         "#{line_content.gsub(/\A\s*/, '')}\n#{' ' * column_without_spaces}#{'^' * underscore_length}"
       end
 

--- a/lib/better_html/test_helper/safe_erb_tester.rb
+++ b/lib/better_html/test_helper/safe_erb_tester.rb
@@ -204,7 +204,7 @@ EOF
                 location: NodeIterator::Location.new(
                   @data,
                   parent_token.code_location.start + expr.start,
-                  parent_token.code_location.start + expr.end
+                  parent_token.code_location.start + expr.end - 1
                 )
               )
             elsif call.method == :html_safe
@@ -213,7 +213,7 @@ EOF
                 location: NodeIterator::Location.new(
                   @data,
                   parent_token.code_location.start + expr.start,
-                  parent_token.code_location.start + expr.end
+                  parent_token.code_location.start + expr.end - 1
                 )
               )
             elsif javascript_attribute_name?(attr_name) && !javascript_safe_method?(call.method)
@@ -222,7 +222,7 @@ EOF
                 location: NodeIterator::Location.new(
                   @data,
                   parent_token.code_location.start + expr.start,
-                  parent_token.code_location.start + expr.end
+                  parent_token.code_location.start + expr.end - 1
                 )
               )
             end

--- a/test/better_html/node_iterator/html_erb_test.rb
+++ b/test/better_html/node_iterator/html_erb_test.rb
@@ -8,7 +8,7 @@ module BetterHtml
         assert_equal 1, scanner.tokens.size
         token = scanner.tokens[0]
         assert_attributes ({ type: :text, text: 'just some text', code: nil }), token
-        assert_attributes ({ start: 0, stop: 14, line: 1, column: 0 }), token.location
+        assert_attributes ({ start: 0, stop: 13, line: 1, column: 0 }), token.location
       end
 
       test "statement" do
@@ -16,7 +16,7 @@ module BetterHtml
         assert_equal 1, scanner.tokens.size
         token = scanner.tokens[0]
         assert_attributes ({ type: :stmt, text: '<% statement %>', code: ' statement ' }), token
-        assert_attributes ({ start: 0, stop: 15, line: 1, column: 0 }), token.location
+        assert_attributes ({ start: 0, stop: 14, line: 1, column: 0 }), token.location
       end
 
       test "when multi byte characters are present in erb" do
@@ -25,7 +25,7 @@ module BetterHtml
         assert_equal 1, scanner.tokens.size
 
         token = scanner.tokens[0]
-        assert_attributes ({ type: :stmt, code: " ui_helper 'your store’s' ", location: { start: 0, stop: 30 } }), token
+        assert_attributes ({ type: :stmt, code: " ui_helper 'your store’s' ", location: { start: 0, stop: 29 } }), token
       end
 
       test "when multi byte characters are present in text" do
@@ -34,7 +34,7 @@ module BetterHtml
         assert_equal 1, scanner.tokens.size
 
         token = scanner.tokens[0]
-        assert_attributes ({ type: :text, text: 'your store’s', location: { start: 0, stop: 12 } }), token
+        assert_attributes ({ type: :text, text: 'your store’s', location: { start: 0, stop: 11 } }), token
       end
 
       test "when multi byte characters are present in html" do
@@ -42,14 +42,14 @@ module BetterHtml
         scanner = BetterHtml::NodeIterator::HtmlErb.new(code)
         assert_equal 14, scanner.tokens.size
 
-        assert_attributes ({ type: :tag_start, text: '<', location: { start: 0, stop: 1 } }), scanner.tokens[0]
-        assert_attributes ({ type: :tag_name, text: 'div', location: { start: 1, stop: 4} }), scanner.tokens[1]
-        assert_attributes ({ type: :whitespace, text: ' ', location: { start: 4, stop: 5 } }), scanner.tokens[2]
-        assert_attributes ({ type: :attribute_name, text: "title", location: { start: 5, stop: 10 } }), scanner.tokens[3]
-        assert_attributes ({ type: :equal, text: "=", location: { start: 10, stop: 11 } }), scanner.tokens[4]
-        assert_attributes ({ type: :attribute_quoted_value_start, text: "'", location: { start: 11, stop: 12 } }), scanner.tokens[5]
-        assert_attributes ({ type: :attribute_quoted_value, text: "your store’s", location: { start: 12, stop: 24 } }), scanner.tokens[6]
-        assert_attributes ({ type: :attribute_quoted_value_end, text: "'", location: { start: 24, stop: 25 } }), scanner.tokens[7]
+        assert_attributes ({ type: :tag_start, text: '<', location: { start: 0, stop: 0 } }), scanner.tokens[0]
+        assert_attributes ({ type: :tag_name, text: 'div', location: { start: 1, stop: 3 } }), scanner.tokens[1]
+        assert_attributes ({ type: :whitespace, text: ' ', location: { start: 4, stop: 4 } }), scanner.tokens[2]
+        assert_attributes ({ type: :attribute_name, text: "title", location: { start: 5, stop: 9 } }), scanner.tokens[3]
+        assert_attributes ({ type: :equal, text: "=", location: { start: 10, stop: 10 } }), scanner.tokens[4]
+        assert_attributes ({ type: :attribute_quoted_value_start, text: "'", location: { start: 11, stop: 11 } }), scanner.tokens[5]
+        assert_attributes ({ type: :attribute_quoted_value, text: "your store’s", location: { start: 12, stop: 23 } }), scanner.tokens[6]
+        assert_attributes ({ type: :attribute_quoted_value_end, text: "'", location: { start: 24, stop: 24 } }), scanner.tokens[7]
       end
 
       test "expression literal" do
@@ -57,7 +57,7 @@ module BetterHtml
         assert_equal 1, scanner.tokens.size
         token = scanner.tokens[0]
         assert_attributes ({ type: :expr_literal, text: '<%= literal %>', code: ' literal ' }), token
-        assert_attributes ({ start: 0, stop: 14, line: 1, column: 0 }), token.location
+        assert_attributes ({ start: 0, stop: 13, line: 1, column: 0 }), token.location
       end
 
       test "expression escaped" do
@@ -65,7 +65,7 @@ module BetterHtml
         assert_equal 1, scanner.tokens.size
         token = scanner.tokens[0]
         assert_attributes ({ type: :expr_escaped, text: '<%== escaped %>', code: ' escaped ' }), token
-        assert_attributes ({ start: 0, stop: 15, line: 1, column: 0 }), token.location
+        assert_attributes ({ start: 0, stop: 14, line: 1, column: 0 }), token.location
       end
 
       test "line number for multi-line statements" do
@@ -87,16 +87,16 @@ module BetterHtml
         assert_equal 4, scanner.tokens.size
 
         assert_attributes ({ type: :text, text: "before\n" }), scanner.tokens[0]
-        assert_attributes ({ line: 1, start: 0, stop: 7 }), scanner.tokens[0].location
+        assert_attributes ({ line: 1, start: 0, stop: 6 }), scanner.tokens[0].location
 
         assert_attributes ({ type: :stmt, text: "<% multi\nline %>" }), scanner.tokens[1]
-        assert_attributes ({ line: 2, start: 7, stop: 23 }), scanner.tokens[1].location
+        assert_attributes ({ line: 2, start: 7, stop: 22 }), scanner.tokens[1].location
 
         assert_attributes ({ type: :text, text: "\n" }), scanner.tokens[2]
-        assert_attributes ({ line: 3, start: 23, stop: 24 }), scanner.tokens[2].location
+        assert_attributes ({ line: 3, start: 23, stop: 23 }), scanner.tokens[2].location
 
         assert_attributes ({ type: :text, text: "after" }), scanner.tokens[3]
-        assert_attributes ({ line: 4, start: 24, stop: 29 }), scanner.tokens[3].location
+        assert_attributes ({ line: 4, start: 24, stop: 28 }), scanner.tokens[3].location
       end
 
       test "multi-line expression with trim" do

--- a/test/better_html/node_iterator/html_lodash_test.rb
+++ b/test/better_html/node_iterator/html_lodash_test.rb
@@ -11,7 +11,7 @@ module BetterHtml
         assert_equal "just some text", token.text
         assert_nil token.code
         assert_equal 0, token.location.start
-        assert_equal 14, token.location.stop
+        assert_equal 13, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 0, token.location.column
       end
@@ -24,7 +24,7 @@ module BetterHtml
         assert_equal "[%= foo %]", token.text
         assert_equal " foo ", token.code
         assert_equal 0, token.location.start
-        assert_equal 10, token.location.stop
+        assert_equal 9, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 0, token.location.column
       end
@@ -37,7 +37,7 @@ module BetterHtml
         assert_equal "[%! foo %]", token.text
         assert_equal " foo ", token.code
         assert_equal 0, token.location.start
-        assert_equal 10, token.location.stop
+        assert_equal 9, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 0, token.location.column
       end
@@ -50,7 +50,7 @@ module BetterHtml
         assert_equal "[% foo %]", token.text
         assert_equal " foo ", token.code
         assert_equal 0, token.location.start
-        assert_equal 9, token.location.stop
+        assert_equal 8, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 0, token.location.column
       end
@@ -64,7 +64,7 @@ module BetterHtml
         assert_equal "before\n", token.text
         assert_nil token.code
         assert_equal 0, token.location.start
-        assert_equal 7, token.location.stop
+        assert_equal 6, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 0, token.location.column
 
@@ -73,7 +73,7 @@ module BetterHtml
         assert_equal "[%= foo %]", token.text
         assert_equal " foo ", token.code
         assert_equal 7, token.location.start
-        assert_equal 17, token.location.stop
+        assert_equal 16, token.location.stop
         assert_equal 2, token.location.line
         assert_equal 0, token.location.column
 
@@ -82,7 +82,7 @@ module BetterHtml
         assert_equal "\nafter", token.text
         assert_nil token.code
         assert_equal 17, token.location.start
-        assert_equal 23, token.location.stop
+        assert_equal 22, token.location.stop
         assert_equal 2, token.location.line
         assert_equal 10, token.location.column
       end
@@ -96,7 +96,7 @@ module BetterHtml
         assert_equal "[% if() { %]", token.text
         assert_equal " if() { ", token.code
         assert_equal 0, token.location.start
-        assert_equal 12, token.location.stop
+        assert_equal 11, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 0, token.location.column
 
@@ -105,7 +105,7 @@ module BetterHtml
         assert_equal "[%= foo %]", token.text
         assert_equal " foo ", token.code
         assert_equal 12, token.location.start
-        assert_equal 22, token.location.stop
+        assert_equal 21, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 12, token.location.column
 
@@ -114,7 +114,7 @@ module BetterHtml
         assert_equal "[% } %]", token.text
         assert_equal " } ", token.code
         assert_equal 22, token.location.start
-        assert_equal 29, token.location.stop
+        assert_equal 28, token.location.stop
         assert_equal 1, token.location.line
         assert_equal 22, token.location.column
       end

--- a/test/better_html/node_iterator/location_test.rb
+++ b/test/better_html/node_iterator/location_test.rb
@@ -4,8 +4,29 @@ require 'better_html/test_helper/safe_erb_tester'
 module BetterHtml
   class NodeIterator
     class LocationTest < ActiveSupport::TestCase
+      test "location start out of bounds" do
+        e = assert_raises(ArgumentError) do
+          Location.new("foo", 5, 6)
+        end
+        assert_equal "start location 5 is out of range for document of size 3", e.message
+      end
+
+      test "location stop out of bounds" do
+        e = assert_raises(ArgumentError) do
+          Location.new("foo", 2, 6)
+        end
+        assert_equal "stop location 6 is out of range for document of size 3", e.message
+      end
+
+      test "location stop < start" do
+        e = assert_raises(ArgumentError) do
+          Location.new("aaaaaa", 5, 2)
+        end
+        assert_equal "end of range must be greater than start of range (2 < 5)", e.message
+      end
+
       test "location without line and column" do
-        loc = Location.new("foo\nbar\nbaz", 9, 10)
+        loc = Location.new("foo\nbar\nbaz", 9, 9)
 
         assert_equal "a", loc.source
         assert_equal 3, loc.line
@@ -13,7 +34,7 @@ module BetterHtml
       end
 
       test "line_source_with_underline" do
-        loc = Location.new("ui_helper(foo)", 10, 13)
+        loc = Location.new("ui_helper(foo)", 10, 12)
 
         assert_equal "foo", loc.source
         assert_equal <<~EOL.strip, loc.line_source_with_underline
@@ -23,7 +44,7 @@ module BetterHtml
       end
 
       test "line_source_with_underline removes empty spaces" do
-        loc = Location.new("   \t   ui_helper(foo)", 17, 20)
+        loc = Location.new("   \t   ui_helper(foo)", 17, 19)
 
         assert_equal "foo", loc.source
         assert_equal <<~EOL.strip, loc.line_source_with_underline


### PR DESCRIPTION
This changes the range for the `Location` object to match the last character of the range, instead of the next character after the range. In other words `Location.new(doc, 0, 0)` selects the first character of the document, where previously `Location.new(doc, 0, 1)` would have selected the first character. Not much of a difference but this is just easier to deal with.

@clayton-shopify 