### PR TITLE
Extract shared ERB code

### DIFF
--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -49,6 +49,9 @@ module BetterHtml
           nodes << consume_element(tokens)
         when :text, :stmt, :expr_literal, :expr_escaped
           nodes << consume_text(tokens)
+        when :debug
+          # <%# debug statements are ignored %>
+          tokens.shift
         else
           raise RuntimeError, "Unhandled token #{token.type} line #{token.location.line} column #{token.location.column}"
         end

--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -49,8 +49,8 @@ module BetterHtml
           nodes << consume_element(tokens)
         when :text, :stmt, :expr_literal, :expr_escaped
           nodes << consume_text(tokens)
-        when :debug
-          # <%# debug statements are ignored %>
+        when :comment
+          # <%# comments are ignored %>
           tokens.shift
         else
           raise RuntimeError, "Unhandled token #{token.type} line #{token.location.line} column #{token.location.column}"

--- a/lib/better_html/test_helper/safe_erb_tester.rb
+++ b/lib/better_html/test_helper/safe_erb_tester.rb
@@ -141,7 +141,7 @@ EOF
           text.content_parts.each do |text_token|
             case text_token.type
             when :stmt, :expr_literal, :expr_escaped
-              next if text_token.type == :stmt && text_token.code.start_with?('#')
+              next if text_token.type == :stmt
               begin
                 expr = RubyExpr.parse(text_token.code)
                 validate_ruby_helper(text_token, expr)
@@ -269,7 +269,7 @@ EOF
 
         def validate_no_statements(node)
           node.content_parts.each do |token|
-            if token.type == :stmt && !(/\A\s*end/m === token.code) && !token.code.start_with?('#')
+            if token.type == :stmt && !(/\A\s*end/m === token.code)
               add_error(
                 "erb statement not allowed here; did you mean '<%=' ?",
                 location: token.location,
@@ -280,7 +280,7 @@ EOF
 
         def validate_no_javascript_tag(node)
           node.content_parts.each do |token|
-            next if token.type == :stmt && token.code.start_with?('#')
+            next if token.type == :stmt
             if [:stmt, :expr_literal, :expr_escaped].include?(token.type)
               expr = begin
                 RubyExpr.parse(token.code)

--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -1,0 +1,78 @@
+require 'erubi'
+require_relative 'token'
+require_relative 'location'
+
+module BetterHtml
+  module Tokenizer
+    class BaseErb < ::Erubi::Engine
+      REGEXP_WITHOUT_TRIM = /<%(={1,2}|%)?(.*?)()?%>([ \t]*\r?\n)?/m
+      STMT_TRIM_MATCHER = /\A(-|#)?(.*?)(-)?\z/m
+      EXPR_TRIM_MATCHER = /\A(.*?)(-)?\z/m
+
+      attr_reader :tokens
+      attr_reader :current_position
+
+      def initialize(document)
+        @document = document
+        @tokens = []
+        @current_position = 0
+        super(document, regexp: REGEXP_WITHOUT_TRIM, trim: false)
+      end
+
+      private
+
+      def append(text)
+        @current_position += text.length
+      end
+
+      def add_code(code)
+        _, ltrim_or_debug, code, rtrim = *STMT_TRIM_MATCHER.match(code)
+        ltrim = ltrim_or_debug if ltrim_or_debug == '-'
+        indicator = ltrim_or_debug if ltrim_or_debug == '#'
+        add_erb_tokens(ltrim, indicator, code, rtrim)
+        append("<%#{ltrim}#{indicator}#{code}#{rtrim}%>")
+      end
+
+      def add_expression(indicator, code)
+        _, code, rtrim = *EXPR_TRIM_MATCHER.match(code)
+        add_erb_tokens(nil, indicator, code, rtrim)
+        append("<%#{indicator}#{code}#{rtrim}%>")
+      end
+
+      def add_erb_tokens(ltrim, indicator, code, rtrim)
+        type = case indicator
+        when nil
+          :stmt
+        when '#'
+          :debug
+        when '='
+          :expr_literal
+        when '=='
+          :expr_escaped
+        else
+          raise ArgumentError
+        end
+
+        start = current_position
+        code_start = start + 2 + (ltrim&.length || 0) + (indicator&.length || 0)
+        code_stop = code_start + code.length
+        stop = code_stop + (rtrim&.length || 0) + 2
+
+        add_token(
+          type, start, stop, nil, nil,
+          code_location: Location.new(@document, code_start, code_stop - 1)
+        )
+      end
+
+      def add_token(type, start, stop, line = nil, column = nil, **extra_attributes)
+        token = Token.new(
+          type: type,
+          location: Location.new(@document, start, stop - 1, line, column),
+          **extra_attributes
+        )
+        @tokens << token
+        token
+      end
+    end
+  end
+end

--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -44,7 +44,7 @@ module BetterHtml
         when nil
           :stmt
         when '#'
-          :debug
+          :comment
         when '='
           :expr_literal
         when '=='

--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -26,9 +26,9 @@ module BetterHtml
       end
 
       def add_code(code)
-        _, ltrim_or_debug, code, rtrim = *STMT_TRIM_MATCHER.match(code)
-        ltrim = ltrim_or_debug if ltrim_or_debug == '-'
-        indicator = ltrim_or_debug if ltrim_or_debug == '#'
+        _, ltrim_or_comment, code, rtrim = *STMT_TRIM_MATCHER.match(code)
+        ltrim = ltrim_or_comment if ltrim_or_comment == '-'
+        indicator = ltrim_or_comment if ltrim_or_comment == '#'
         add_erb_tokens(ltrim, indicator, code, rtrim)
         append("<%#{ltrim}#{indicator}#{code}#{rtrim}%>")
       end

--- a/lib/better_html/tokenizer/html_erb.rb
+++ b/lib/better_html/tokenizer/html_erb.rb
@@ -1,69 +1,37 @@
-require 'erubi'
 require 'html_tokenizer'
-require_relative 'token'
-require_relative 'location'
+require_relative 'base_erb'
 
 module BetterHtml
   module Tokenizer
-    class HtmlErb < ::Erubi::Engine
-      attr_reader :tokens
+    class HtmlErb < BaseErb
       attr_reader :parser
 
       REGEXP_WITHOUT_TRIM = /<%(={1,2}|-|%)?(.*?)(?:[-=])?()?%>([ \t]*\r?\n)?/m
 
       def initialize(document)
         @parser = HtmlTokenizer::Parser.new
-        @tokens = []
-        @document = document
-        super(document, regexp: REGEXP_WITHOUT_TRIM, trim: false)
+        super(document)
       end
 
-      def add_text(text)
-        @parser.parse(text) { |*args| add_tokens(*args) }
-      end
-
-      def add_code(code)
-        text = "<%#{code}%>"
-        start = @parser.document_length
-        stop = start + text.size - 1
-        @tokens << Token.new(
-          type: :stmt,
-          code: code,
-          text: text,
-          location: Location.new(@document, start, stop, @parser.line_number, @parser.column_number),
-          code_location: Location.new(@document, start+2, stop-2, @parser.line_number, @parser.column_number+2)
-        )
-        @parser.append_placeholder(text)
-      end
-
-      def add_expression(indicator, code)
-        text = "<%#{indicator}#{code}%>"
-        start = @parser.document_length
-        stop = start + text.size - 1
-        @tokens << Token.new(
-          type: indicator == '=' ? :expr_literal : :expr_escaped,
-          code: code,
-          text: text,
-          location: Location.new(@document, start, stop, @parser.line_number, @parser.column_number),
-          code_location: Location.new(@document, start+2+indicator.size, stop-2, @parser.line_number, @parser.column_number+2+indicator.size)
-        )
-        @parser.append_placeholder(text)
+      def current_position
+        @parser.document_length
       end
 
       private
 
-      def add_tokens(type, start, stop, line, column)
-        extra_attributes = if type == :tag_end
-          {
-            self_closing: @parser.self_closing_tag?
-          }
+      def append(text)
+        @parser.append_placeholder(text)
+      end
+
+      def add_text(text)
+        @parser.parse(text) do |type, start, stop, line, column|
+          extra_attributes = if type == :tag_end
+            {
+              self_closing: @parser.self_closing_tag?
+            }
+          end
+          add_token(type, start, stop, nil, nil, **(extra_attributes || {}))
         end
-        @tokens << Token.new(
-          type: type,
-          text: @parser.document[start...stop],
-          location: Location.new(@document, start, stop - 1, line, column),
-          **(extra_attributes || {})
-        )
       end
     end
   end

--- a/lib/better_html/tokenizer/javascript_erb.rb
+++ b/lib/better_html/tokenizer/javascript_erb.rb
@@ -1,52 +1,15 @@
 require 'erubi'
-require_relative 'token'
-require_relative 'location'
+require_relative 'base_erb'
 
 module BetterHtml
   module Tokenizer
-    class JavascriptErb < ::Erubi::Engine
-      attr_reader :tokens
-
-      def initialize(source)
-        @source = source
-        @parsed_document = ""
-        @tokens = []
-        super(source, regexp: HtmlErb::REGEXP_WITHOUT_TRIM, trim: false)
-      end
-
-      def add_text(text)
-        add_token(:text, text) if text.present?
-        append(text)
-      end
-
-      def add_code(code)
-        text = "<%#{code}%>"
-        add_token(:stmt, text, code)
-        append(text)
-      end
-
-      def add_expression(indicator, code)
-        text = "<%#{indicator}#{code}%>"
-        add_token(indicator == '=' ? :expr_literal : :expr_escaped, text, code)
-        append(text)
-      end
-
+    class JavascriptErb < BaseErb
       private
 
-      def add_token(type, text, code = nil)
-        raise ArgumentError, "empty #{type} token" if text.size == 0
-        start = @parsed_document.size
-        stop = start + text.size - 1
-        @tokens << Token.new(
-          type: type,
-          text: text,
-          code: code,
-          location: Location.new(@source, start, stop)
-        )
-      end
-
-      def append(text)
-        @parsed_document << text
+      def add_text(text)
+        pos = current_position
+        add_token(:text, pos, pos + text.size) if text.present?
+        append(text)
       end
     end
   end

--- a/lib/better_html/tokenizer/location.rb
+++ b/lib/better_html/tokenizer/location.rb
@@ -42,10 +42,12 @@ module BetterHtml
       private
 
       def calculate_line
+        return 1 if start == 0
         @document[0..start-1].scan("\n").count + 1
       end
 
       def calculate_column
+        return 0 if start == 0
         @document[0..start-1]&.split("\n", -1)&.last&.length || 0
       end
 

--- a/lib/better_html/tokenizer/token.rb
+++ b/lib/better_html/tokenizer/token.rb
@@ -1,8 +1,22 @@
-require 'ostruct'
-
 module BetterHtml
   module Tokenizer
-    class Token < OpenStruct
+    class Token
+      attr_reader :type, :location, :code_location, :self_closing
+
+      def initialize(type:, location:, code_location: nil, self_closing: nil)
+        @type = type
+        @location = location
+        @code_location = code_location
+        @self_closing = self_closing
+      end
+
+      def code
+        code_location&.source
+      end
+
+      def text
+        location&.source
+      end
     end
   end
 end

--- a/test/better_html/tokenizer/html_erb_test.rb
+++ b/test/better_html/tokenizer/html_erb_test.rb
@@ -124,7 +124,7 @@ module BetterHtml
         assert_attributes ({ type: :text, text: "before\n" }), scanner.tokens[0]
         assert_attributes ({ line: 1 }), scanner.tokens[0].location
 
-        assert_attributes ({ type: :debug, text: "<%# BO$$ Mode %>" }), scanner.tokens[1]
+        assert_attributes ({ type: :comment, text: "<%# BO$$ Mode %>" }), scanner.tokens[1]
         assert_attributes ({ line: 2 }), scanner.tokens[1].location
 
         assert_attributes ({ type: :text, text: "\n" }), scanner.tokens[2]

--- a/test/better_html/tokenizer/html_erb_test.rb
+++ b/test/better_html/tokenizer/html_erb_test.rb
@@ -90,14 +90,14 @@ module BetterHtml
         assert_attributes ({ type: :text, text: "before\n" }), scanner.tokens[0]
         assert_attributes ({ line: 1, start: 0, stop: 6 }), scanner.tokens[0].location
 
-        assert_attributes ({ type: :stmt, text: "<% multi\nline %>" }), scanner.tokens[1]
-        assert_attributes ({ line: 2, start: 7, stop: 22 }), scanner.tokens[1].location
+        assert_attributes ({ type: :stmt, text: "<% multi\nline -%>" }), scanner.tokens[1]
+        assert_attributes ({ line: 2, start: 7, stop: 23 }), scanner.tokens[1].location
 
         assert_attributes ({ type: :text, text: "\n" }), scanner.tokens[2]
-        assert_attributes ({ line: 3, start: 23, stop: 23 }), scanner.tokens[2].location
+        assert_attributes ({ line: 3, start: 24, stop: 24 }), scanner.tokens[2].location
 
         assert_attributes ({ type: :text, text: "after" }), scanner.tokens[3]
-        assert_attributes ({ line: 4, start: 24, stop: 28 }), scanner.tokens[3].location
+        assert_attributes ({ line: 4, start: 25, stop: 29 }), scanner.tokens[3].location
       end
 
       test "multi-line expression with trim" do
@@ -107,7 +107,7 @@ module BetterHtml
         assert_attributes ({ type: :text, text: "before\n" }), scanner.tokens[0]
         assert_attributes ({ line: 1 }), scanner.tokens[0].location
 
-        assert_attributes ({ type: :expr_literal, text: "<%= multi\nline %>" }), scanner.tokens[1]
+        assert_attributes ({ type: :expr_literal, text: "<%= multi\nline -%>" }), scanner.tokens[1]
         assert_attributes ({ line: 2 }), scanner.tokens[1].location
 
         assert_attributes ({ type: :text, text: "\n" }), scanner.tokens[2]
@@ -124,7 +124,7 @@ module BetterHtml
         assert_attributes ({ type: :text, text: "before\n" }), scanner.tokens[0]
         assert_attributes ({ line: 1 }), scanner.tokens[0].location
 
-        assert_attributes ({ type: :stmt, text: "<%# BO$$ Mode %>" }), scanner.tokens[1]
+        assert_attributes ({ type: :debug, text: "<%# BO$$ Mode %>" }), scanner.tokens[1]
         assert_attributes ({ line: 2 }), scanner.tokens[1].location
 
         assert_attributes ({ type: :text, text: "\n" }), scanner.tokens[2]


### PR DESCRIPTION
This is another extraction from https://github.com/Shopify/better-html/pull/15, which brings better support for ERB debug statements, trim modes and extract common code between JavascriptErb and HtmlErb into a parent class.

@clayton-shopify 