### PR TITLE
Extract iterators from #15

### DIFF
--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -27,7 +27,8 @@ module BetterHtml
     end
 
     def nodes_with_type(*type)
-      nodes.select{ |node| Array.wrap(type).include?(node.type) }
+      types = Array.wrap(type)
+      nodes.select{ |node| types.include?(node.type) }
     end
 
     def nodes

--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -9,11 +9,7 @@ require_relative 'parser/text'
 
 module BetterHtml
   class Parser
-    attr_reader :nodes, :template_language
-
-    delegate :each, :each_with_index, :[], to: :nodes
-    delegate :parser, to: :@erb, allow_nil: true
-    delegate :errors, to: :parser, allow_nil: true, prefix: true
+    attr_reader :template_language
 
     def initialize(document, template_language: :html)
       @document = document
@@ -28,36 +24,39 @@ module BetterHtml
       else
         raise ArgumentError, "template_language can be :html or :javascript"
       end
-      @nodes = parse!
+    end
+
+    def nodes_with_type(*type)
+      nodes.select{ |node| Array.wrap(type).include?(node.type) }
+    end
+
+    def nodes
+      @nodes ||= [].tap do |array|
+        tokens = @erb.tokens.dup
+        while token = tokens[0]
+          case token.type
+          when :cdata_start
+            tokens.shift
+            array << consume_cdata(tokens)
+          when :comment_start
+            tokens.shift
+            array << consume_comment(tokens)
+          when :tag_start
+            tokens.shift
+            array << consume_element(tokens)
+          when :text, :stmt, :expr_literal, :expr_escaped
+            array << consume_text(tokens)
+          when :comment
+            # <%# comments are ignored %>
+            tokens.shift
+          else
+            raise RuntimeError, "Unhandled token #{token.type} line #{token.location.line} column #{token.location.column}"
+          end
+        end
+      end
     end
 
     private
-
-    def parse!
-      nodes = []
-      tokens = @erb.tokens.dup
-      while token = tokens[0]
-        case token.type
-        when :cdata_start
-          tokens.shift
-          nodes << consume_cdata(tokens)
-        when :comment_start
-          tokens.shift
-          nodes << consume_comment(tokens)
-        when :tag_start
-          tokens.shift
-          nodes << consume_element(tokens)
-        when :text, :stmt, :expr_literal, :expr_escaped
-          nodes << consume_text(tokens)
-        when :comment
-          # <%# comments are ignored %>
-          tokens.shift
-        else
-          raise RuntimeError, "Unhandled token #{token.type} line #{token.location.line} column #{token.location.column}"
-        end
-      end
-      nodes
-    end
 
     def consume_cdata(tokens)
       node = CData.new

--- a/lib/better_html/parser/attribute.rb
+++ b/lib/better_html/parser/attribute.rb
@@ -10,25 +10,6 @@ module BetterHtml
         @name_parts = []
         @value_parts = []
       end
-
-      def unescaped_value_parts
-        value_parts.map do |part|
-          next if ["'", '"'].include?(part.text)
-          if [:attribute_quoted_value, :attribute_unquoted_value].include?(part.type)
-            CGI.unescapeHTML(part.text)
-          else
-            part.text
-          end
-        end.compact
-      end
-
-      def unescaped_value
-        unescaped_value_parts.join
-      end
-
-      def value_without_quotes
-        value_parts.map{ |s| ["'", '"'].include?(s.text) ? '' : s.text }.join
-      end
     end
   end
 end

--- a/lib/better_html/parser/base.rb
+++ b/lib/better_html/parser/base.rb
@@ -11,14 +11,14 @@ module BetterHtml
         RUBY
       end
 
-      def node_type
+      def type
         self.class.name.split('::').last.downcase.to_sym
       end
 
       %w(text cdata comment element).each do |name|
         class_eval <<~RUBY
           def #{name}?
-            node_type == :#{name}
+            type == :#{name}
           end
         RUBY
       end

--- a/lib/better_html/parser/element.rb
+++ b/lib/better_html/parser/element.rb
@@ -13,14 +13,6 @@ module BetterHtml
         @name_parts = []
         @attributes = []
       end
-
-      def find_attr(wanted)
-        @attributes.each do |attribute|
-          return attribute if attribute.name == wanted
-        end
-        nil
-      end
-      alias_method :[], :find_attr
     end
   end
 end

--- a/lib/better_html/tokenizer/html_erb.rb
+++ b/lib/better_html/tokenizer/html_erb.rb
@@ -6,8 +6,6 @@ module BetterHtml
     class HtmlErb < BaseErb
       attr_reader :parser
 
-      REGEXP_WITHOUT_TRIM = /<%(={1,2}|-|%)?(.*?)(?:[-=])?()?%>([ \t]*\r?\n)?/m
-
       def initialize(document)
         @parser = HtmlTokenizer::Parser.new
         super(document)

--- a/lib/better_html/tokenizer/html_lodash.rb
+++ b/lib/better_html/tokenizer/html_lodash.rb
@@ -31,7 +31,7 @@ module BetterHtml
               add_text(pre_match) if pre_match.present?
             end
             match = captures[1]
-            token = if code = lodash_escape.match(match)
+            if code = lodash_escape.match(match)
               add_lodash_tokens("=", code.captures[0])
             elsif code = lodash_interpolate.match(match)
               add_lodash_tokens("!", code.captures[0])

--- a/lib/better_html/tokenizer/javascript_erb.rb
+++ b/lib/better_html/tokenizer/javascript_erb.rb
@@ -1,4 +1,3 @@
-require 'erubi'
 require_relative 'base_erb'
 
 module BetterHtml

--- a/lib/better_html/tree/attribute.rb
+++ b/lib/better_html/tree/attribute.rb
@@ -1,0 +1,24 @@
+module BetterHtml
+  module Tree
+    class Attribute
+      attr_reader :node
+
+      def initialize(node)
+        @node = node
+      end
+
+      def loc
+        @node.name_parts.first&.location
+      end
+
+      def name
+        @node&.name&.downcase
+      end
+
+      def value
+        parts = @node.value_parts.reject{ |node| ["'", '"'].include?(node.text) }
+        parts.map { |s| [:attribute_quoted_value, :attribute_unquoted_value].include?(s.type) ? CGI.unescapeHTML(s.text) : s.text  }.join
+      end
+    end
+  end
+end

--- a/lib/better_html/tree/attribute.rb
+++ b/lib/better_html/tree/attribute.rb
@@ -3,6 +3,9 @@ module BetterHtml
     class Attribute
       attr_reader :node
 
+      QUOTES_TOKEN_TYPES = [:attribute_quoted_value_start, :attribute_quoted_value_end]
+      VALUE_TOKEN_TYPES = [:attribute_quoted_value, :attribute_unquoted_value]
+
       def initialize(node)
         @node = node
       end
@@ -16,8 +19,8 @@ module BetterHtml
       end
 
       def value
-        parts = @node.value_parts.reject{ |node| ["'", '"'].include?(node.text) }
-        parts.map { |s| [:attribute_quoted_value, :attribute_unquoted_value].include?(s.type) ? CGI.unescapeHTML(s.text) : s.text  }.join
+        parts = @node.value_parts.reject{ |node| QUOTES_TOKEN_TYPES.include?(node.type) }
+        parts.map { |s| VALUE_TOKEN_TYPES.include?(s.type) ? CGI.unescapeHTML(s.text) : s.text }.join
       end
     end
   end

--- a/lib/better_html/tree/attributes_list.rb
+++ b/lib/better_html/tree/attributes_list.rb
@@ -1,0 +1,25 @@
+require 'better_html/tree/attribute'
+
+module BetterHtml
+  module Tree
+    class AttributesList
+      def initialize(list)
+        @list = list || []
+      end
+
+      def self.from_nodes(nodes)
+        new(nodes&.map { |node| Tree::Attribute.new(node) })
+      end
+
+      def [](name)
+        @list.find do |attribute|
+          attribute.name == name.downcase
+        end
+      end
+
+      def each(&block)
+        @list.each(&block)
+      end
+    end
+  end
+end

--- a/lib/better_html/tree/tag.rb
+++ b/lib/better_html/tree/tag.rb
@@ -1,0 +1,33 @@
+require 'better_html/tree/attributes_list'
+
+module BetterHtml
+  module Tree
+    class Tag
+      attr_reader :node
+
+      def initialize(node)
+        @node = node
+      end
+
+      def loc
+        @node.name_parts.first&.location
+      end
+
+      def name
+        @node&.name&.downcase
+      end
+
+      def closing?
+        @node.closing?
+      end
+
+      def self_closing?
+        @node.self_closing?
+      end
+
+      def attributes
+        @attributes ||= AttributesList.from_nodes(@node.attributes)
+      end
+    end
+  end
+end

--- a/test/better_html/parser_test.rb
+++ b/test/better_html/parser_test.rb
@@ -149,36 +149,6 @@ module BetterHtml
       assert_equal ['"', "some ", "<%= value %>", " foo", '"'], attribute.value_parts.map(&:text)
     end
 
-    test "attributes can be accessed through [] on Element object" do
-      tree = BetterHtml::Parser.new("<div foo=\"bar\">")
-
-      assert_equal 1, tree.nodes.size
-      element = tree.nodes.first
-      assert_equal BetterHtml::Parser::Element, element.class
-      assert_equal 1, element.attributes.size
-      assert_nil element['nonexistent']
-      refute_nil attribute = element['foo']
-      assert_equal BetterHtml::Parser::Attribute, attribute.class
-    end
-
-    test "attribute values can be read unescaped" do
-      tree = BetterHtml::Parser.new("<div foo=\"&lt;&quot;&gt;\">")
-
-      element = tree.nodes.first
-      assert_equal 1, element.attributes.size
-      attribute = element['foo']
-      assert_equal '<">', attribute.unescaped_value
-    end
-
-    test "attribute values does not unescape stuff inside erb" do
-      tree = BetterHtml::Parser.new("<div foo=\"&lt;<%= &gt; %>&gt;\">")
-
-      element = tree.nodes.first
-      assert_equal 1, element.attributes.size
-      attribute = element['foo']
-      assert_equal '<<%= &gt; %>>', attribute.unescaped_value
-    end
-
     test "consume text nodes" do
       tree = BetterHtml::Parser.new("here is <%= some %> text")
 

--- a/test/better_html/test_helper/safe_erb_tester_test.rb
+++ b/test/better_html/test_helper/safe_erb_tester_test.rb
@@ -281,6 +281,17 @@ module BetterHtml
         assert_equal "erb statement not allowed here; did you mean '<%=' ?", errors.first.message
       end
 
+      test "disallowed script types" do
+        errors = parse(<<-EOF).errors
+          <script type="text/bogus">
+          </script>
+        EOF
+
+        assert_equal 1, errors.size
+        assert_equal 'type', errors.first.location.source
+        assert_equal "text/bogus is not a valid type, valid types are text/javascript, text/template, text/html", errors.first.message
+      end
+
       test "statements not allowed in javascript template" do
         errors = parse(<<-JS, template_language: :javascript).errors
           <% if foo %>

--- a/test/better_html/test_helper/safe_lodash_tester_test.rb
+++ b/test/better_html/test_helper/safe_lodash_tester_test.rb
@@ -50,6 +50,16 @@ module BetterHtml
         assert_equal "No script tags allowed nested in lodash templates", errors.first.message
       end
 
+      test "script tag names are unescaped" do
+        errors = parse(<<-EOF).errors
+          <script type="text/j&#x61;v&#x61;script"></script>
+        EOF
+
+        assert_equal 1, errors.size
+        assert_equal 'script', errors.first.location.source
+        assert_equal "No script tags allowed nested in lodash templates", errors.first.message
+      end
+
       test "statement not allowed in attribute name" do
         errors = parse(<<-EOF).errors
           <div class[% if (foo) %]="foo">


### PR DESCRIPTION
This extracts iterators from #15. This is needed to rewrite `BetterHtml::Parser` using [`AST`](https://github.com/whitequark/ast). As [this note explains](https://github.com/whitequark/ast/blob/master/lib/ast/node.rb#L7) nodes in the AST are all instances of `AST::Node` and don't know how to traverse themselves, which is why these new methods are needed.

The `BetterHtml::Parser` class defines a `nodes` and `nodes_with_type` method that behave like `Enumerable`s.

Because the `AST::Node` objects are so simple, they don't know how to introspect themselves either, for example answering "is `</div>` a closing node" involves looking at the first child of a node to see if it is a `AST::Node` with type `:solidus`. This is where `Tree::Tag`, `Tree::AttributesList` and `Tree::Attribute` come in. For now they only delegate their methods to other objects but in #15 they would do the heavy lifting of answering high level questions about to `AST::Node` objects.

@clayton-shopify 