### PR TITLE
Better detection of unsafe helpers in html tags

### DIFF
--- a/lib/better_html/test_helper/ruby_node.rb
+++ b/lib/better_html/test_helper/ruby_node.rb
@@ -38,8 +38,9 @@ module BetterHtml
 
       STATIC_TYPES = [:str, :int, :true, :false, :nil]
 
-      def static_type?
-        type?(STATIC_TYPES)
+      def static_value?
+        type?(STATIC_TYPES) ||
+          (type?(:dstr) && !children.any? { |child| !child.type?(:str) })
       end
 
       def return_values
@@ -63,12 +64,7 @@ module BetterHtml
 
       def static_return_value?
         return false if (possible_values = return_values.to_a).empty?
-        possible_values.each do |node|
-          next if node.static_type?
-          return false unless node.type?(:dstr)
-          return false if node.children.any? { |child| !child.type?(:str) }
-        end
-        true
+        possible_values.all?(&:static_value?)
       end
 
       def method_call?

--- a/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
@@ -28,8 +28,12 @@ module BetterHtml
             source = code_node.loc.source
 
             if indicator == '='
-              ruby_node = RubyNode.parse(source)
-              validate_tag_interpolation(code_node, ruby_node, attribute.name) if ruby_node
+              if (ruby_node = RubyNode.parse(source))
+                no_unsafe_calls(code_node, ruby_node)
+                unless ruby_node.static_return_value?
+                  handle_missing_safe_wrapper(code_node, ruby_node, attribute.name)
+                end
+              end
             elsif indicator == '=='
               add_error(
                 "erb interpolation with '<%==' inside html attribute is never safe",
@@ -45,78 +49,103 @@ module BetterHtml
             next if indicator == '#'
             source = code_node.loc.source
 
-            ruby_node = RubyNode.parse(source)
-            validate_ruby_helper(code_node, ruby_node) if ruby_node
+            next unless (ruby_node = RubyNode.parse(source))
+            no_unsafe_calls(code_node, ruby_node)
+            validate_ruby_helper(code_node, ruby_node)
           end
         end
 
-        def validate_ruby_helper(parent_token, ruby_node)
+        def validate_ruby_helper(parent_node, ruby_node)
           ruby_node.descendants(:send, :csend).each do |send_node|
-            send_node.child_nodes.select(&:hash?).each do |hash_node|
+            send_node.descendants(:hash).each do |hash_node|
               hash_node.child_nodes.select(&:pair?).each do |pair_node|
-                validate_ruby_helper_hash_entry(parent_token, ruby_node, nil, *pair_node.children)
+                validate_ruby_helper_hash_entry(parent_node, ruby_node, nil, *pair_node.children)
               end
             end
           end
         end
 
-        def validate_ruby_helper_hash_entry(parent_token, ruby_node, key_prefix, key_node, value_node)
+        def validate_ruby_helper_hash_entry(parent_node, ruby_node, key_prefix, key_node, value_node)
           return unless [:sym, :str].include?(key_node.type)
           key = [key_prefix, key_node.children.first.to_s].compact.join('-').dasherize
           case value_node.type
           when :dstr
-            validate_ruby_helper_hash_value(parent_token, ruby_node, key, value_node)
+            validate_ruby_helper_hash_value(parent_node, ruby_node, key, value_node)
           when :hash
             if key == 'data'
               value_node.child_nodes.select(&:pair?).each do |pair_node|
-                validate_ruby_helper_hash_entry(parent_token, ruby_node, key, *pair_node.children)
+                validate_ruby_helper_hash_entry(parent_node, ruby_node, key, *pair_node.children)
               end
             end
           end
         end
 
-        def validate_ruby_helper_hash_value(parent_token, ruby_node, attr_name, hash_value)
+        def validate_ruby_helper_hash_value(parent_node, ruby_node, attr_name, hash_value)
           hash_value.child_nodes.select(&:begin?).each do |begin_node|
-            validate_tag_interpolation(parent_token, begin_node, attr_name)
+            validate_tag_interpolation(parent_node, begin_node, attr_name)
           end
         end
 
-        def validate_tag_interpolation(parent_token, ruby_node, attr_name)
-          return if ruby_node.static_return_value?
-
-          location = Tokenizer::Location.new(
-            parent_token.loc.document,
-            parent_token.loc.start + ruby_node.loc.expression.begin_pos,
-            parent_token.loc.start + ruby_node.loc.expression.end_pos - 1
-          )
-
+        def handle_missing_safe_wrapper(parent_node, ruby_node, attr_name)
+          return unless @config.javascript_attribute_name?(attr_name)
           method_calls = ruby_node.return_values.select(&:method_call?)
-          if @config.javascript_attribute_name?(attr_name) && method_calls.empty?
+          unsafe_calls = method_calls.select { |node| !@config.javascript_safe_method?(node.method_name) }
+          if method_calls.empty?
             add_error(
-              "erb interpolation in javascript attribute must call '(...).to_json'",
-              location: location
+              "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'",
+              location: nested_location(parent_node, ruby_node)
             )
-            return
+            true
+          elsif unsafe_calls.any?
+            unsafe_calls.each do |call_node|
+              add_error(
+                "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'",
+                location: nested_location(parent_node, call_node)
+              )
+            end
+            true
           end
+        end
 
-          method_calls.each do |call|
-            if call.method_name?(:raw)
+        def validate_tag_interpolation(parent_node, ruby_node, attr_name)
+          return if ruby_node.static_return_value?
+          return if handle_missing_safe_wrapper(parent_node, ruby_node, attr_name)
+
+          ruby_node.return_values.each do |call_node|
+            next if call_node.static_return_value?
+
+            if @config.javascript_attribute_name?(attr_name) &&
+                  !@config.javascript_safe_method?(call_node.method_name)
               add_error(
-                "erb interpolation with '<%= raw(...) %>' inside html attribute is never safe",
-                location: location
-              )
-            elsif call.method_name?(:html_safe)
-              add_error(
-                "erb interpolation with '<%= (...).html_safe %>' inside html attribute is never safe",
-                location: location
-              )
-            elsif @config.javascript_attribute_name?(attr_name) && !@config.javascript_safe_method?(call.method_name)
-              add_error(
-                "erb interpolation in javascript attribute must call '(...).to_json'",
-                location: location
+                "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'",
+                location: nested_location(parent_node, ruby_node)
               )
             end
           end
+        end
+
+        def no_unsafe_calls(parent_node, ruby_node)
+          ruby_node.descendants(:send, :csend).each do |call|
+            if call.method_name?(:raw)
+              add_error(
+                "erb interpolation with '<%= raw(...) %>' in this context is never safe",
+                location: nested_location(parent_node, ruby_node)
+              )
+            elsif call.method_name?(:html_safe)
+              add_error(
+                "erb interpolation with '<%= (...).html_safe %>' in this context is never safe",
+                location: nested_location(parent_node, ruby_node)
+              )
+            end
+          end
+        end
+
+        def nested_location(parent_node, ruby_node)
+          Tokenizer::Location.new(
+            parent_node.loc.document,
+            parent_node.loc.start + ruby_node.loc.expression.begin_pos,
+            parent_node.loc.start + ruby_node.loc.expression.end_pos - 1
+          )
         end
       end
     end

--- a/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
@@ -14,11 +14,21 @@ module BetterHtml
           end
 
           @parser.nodes_with_type(:text).each do |node|
-            validate_text_node(node)
+            validate_text_node(node) unless in_script_tag?(node)
           end
         end
 
         private
+
+        def in_script_tag?(node)
+          ast = @parser.ast.to_a
+          index = ast.find_index(node)
+          return unless (previous_node = ast[index - 1])
+          return unless previous_node.type == :tag
+
+          tag = BetterHtml::Tree::Tag.from_node(previous_node)
+          tag.name == "script" && !tag.closing?
+        end
 
         def validate_attribute(attribute)
           erb_nodes(attribute.value_node).each do |erb_node, indicator_node, code_node|

--- a/test/better_html/test_helper/safe_erb/tag_interpolation_test.rb
+++ b/test/better_html/test_helper/safe_erb/tag_interpolation_test.rb
@@ -12,6 +12,30 @@ module BetterHtml
           )
         end
 
+        test "raw in <script> tag" do
+          errors = validate(<<-EOF).errors
+            <script>var myData = <%= raw(foo.to_json) %>;</script>
+          EOF
+
+          assert_equal 0, errors.size
+        end
+
+        test "html_safe in <script> tag" do
+          errors = validate(<<-EOF).errors
+            <script>var myData = <%= foo.to_json.html_safe %>;</script>
+          EOF
+
+          assert_equal 0, errors.size
+        end
+
+        test "<%== in <script> tag" do
+          errors = validate(<<-EOF).errors
+            <script>var myData = <%== foo.to_json %>;</script>
+          EOF
+
+          assert_equal 0, errors.size
+        end
+
         test "string without interpolation is safe" do
           errors = validate(<<-EOF).errors
             <a onclick="alert('<%= "something" %>')">

--- a/test/better_html/test_helper/safe_erb/tag_interpolation_test.rb
+++ b/test/better_html/test_helper/safe_erb/tag_interpolation_test.rb
@@ -26,8 +26,8 @@ module BetterHtml
           EOF
 
           assert_equal 1, errors.size
-          assert_equal '"hello #{name}"', errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal 'name', errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
         end
 
         test "string with interpolation and ternary" do
@@ -37,11 +37,11 @@ module BetterHtml
 
           assert_equal 2, errors.size
 
-          assert_equal '"hello #{foo ? bar : baz}" if bla?', errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal 'bar', errors[0].location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors[0].message
 
-          assert_equal '"hello #{foo ? bar : baz}" if bla?', errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal 'baz', errors[1].location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors[1].message
         end
 
         test "plain erb tag in html attribute" do
@@ -51,7 +51,7 @@ module BetterHtml
 
           assert_equal 1, errors.size
           assert_equal 'unsafe', errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
         end
 
         test "to_json is safe in html attribute" do
@@ -74,8 +74,8 @@ module BetterHtml
           EOF
 
           assert_equal 1, errors.size
-          assert_equal 'foo ? bar : j(baz)', errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal 'bar', errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
         end
 
         test "j is safe in html attribute" do
@@ -113,7 +113,7 @@ module BetterHtml
 
           assert_equal 1, errors.size
           assert_equal 'unsafe.html_safe', errors.first.location.source
-          assert_equal "erb interpolation with '<%= (...).html_safe %>' inside html attribute is never safe", errors.first.message
+          assert_equal "erb interpolation with '<%= (...).html_safe %>' in this context is never safe", errors.first.message
         end
 
         test "html_safe is never safe in html attribute, even with to_json" do
@@ -121,9 +121,11 @@ module BetterHtml
             <a onclick="method(<%= unsafe.to_json.html_safe %>)">
           EOF
 
-          assert_equal 1, errors.size
-          assert_equal 'unsafe.to_json.html_safe', errors.first.location.source
-          assert_equal "erb interpolation with '<%= (...).html_safe %>' inside html attribute is never safe", errors.first.message
+          assert_equal 2, errors.size
+          assert_equal 'unsafe.to_json.html_safe', errors[0].location.source
+          assert_equal "erb interpolation with '<%= (...).html_safe %>' in this context is never safe", errors[0].message
+          assert_equal 'unsafe.to_json.html_safe', errors[1].location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors[1].message
         end
 
         test "<%== is never safe in html attribute, even non javascript attributes like href" do
@@ -153,7 +155,7 @@ module BetterHtml
 
           assert_equal 1, errors.size
           assert_equal 'raw unsafe', errors.first.location.source
-          assert_equal "erb interpolation with '<%= raw(...) %>' inside html attribute is never safe", errors.first.message
+          assert_equal "erb interpolation with '<%= raw(...) %>' in this context is never safe", errors.first.message
         end
 
         test "raw is never safe in html attribute, even with to_json" do
@@ -161,9 +163,11 @@ module BetterHtml
             <a onclick="method(<%= raw unsafe.to_json %>)">
           EOF
 
-          assert_equal 1, errors.size
-          assert_equal 'raw unsafe.to_json', errors.first.location.source
-          assert_equal "erb interpolation with '<%= raw(...) %>' inside html attribute is never safe", errors.first.message
+          assert_equal 2, errors.size
+          assert_equal 'raw unsafe.to_json', errors[0].location.source
+          assert_equal "erb interpolation with '<%= raw(...) %>' in this context is never safe", errors[0].message
+          assert_equal 'raw unsafe.to_json', errors[1].location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors[1].message
         end
 
         test "unsafe javascript methods in helper calls with new hash syntax" do
@@ -172,8 +176,8 @@ module BetterHtml
           EOF
 
           assert_equal 1, errors.size
-          assert_equal "\#{unsafe}", errors[0].location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors[0].message
+          assert_equal "unsafe", errors[0].location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors[0].message
         end
 
         test "unsafe javascript methods in helper calls with old hash syntax" do
@@ -182,8 +186,8 @@ module BetterHtml
           EOF
 
           assert_equal 1, errors.size
-          assert_equal "\#{unsafe}", errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal "unsafe", errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
         end
 
         test "unsafe javascript methods in helper calls with string as key" do
@@ -192,8 +196,8 @@ module BetterHtml
           EOF
 
           assert_equal 1, errors.size
-          assert_equal "\#{unsafe}", errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal "unsafe", errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
         end
 
         test "unsafe javascript methods in helper calls with nested data key" do
@@ -202,8 +206,38 @@ module BetterHtml
           EOF
 
           assert_equal 1, errors.size
-          assert_equal "\#{unsafe}", errors.first.location.source
-          assert_equal "erb interpolation in javascript attribute must call '(...).to_json'", errors.first.message
+          assert_equal "unsafe", errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
+        end
+
+        test "unsafe javascript methods in helper calls with more than one level of nested data key" do
+          errors = validate(<<-EOF).errors
+            <%= ui_my_helper(:foo, inner_html: { data: { eval: "alert(\#{unsafe})" } }) %>
+          EOF
+
+          assert_equal 1, errors.size
+          assert_equal "unsafe", errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
+        end
+
+        test "using raw anywhere in helpers" do
+          errors = validate(<<-EOF).errors
+            <%= ui_my_helper(:foo, help_text: raw("foo")) %>
+          EOF
+
+          assert_equal 1, errors.size
+          assert_equal "ui_my_helper(:foo, help_text: raw(\"foo\"))", errors.first.location.source
+          assert_equal "erb interpolation with '<%= raw(...) %>' in this context is never safe", errors.first.message
+        end
+
+        test "using raw anywhere in html tags" do
+          errors = validate(<<-EOF).errors
+            <a "<%= raw("hello") %>">
+          EOF
+
+          assert_equal 1, errors.size
+          assert_equal "raw(\"hello\")", errors.first.location.source
+          assert_equal "erb interpolation with '<%= raw(...) %>' in this context is never safe", errors.first.message
         end
 
         private

--- a/test/better_html/test_helper/safe_erb/tag_interpolation_test.rb
+++ b/test/better_html/test_helper/safe_erb/tag_interpolation_test.rb
@@ -190,6 +190,24 @@ module BetterHtml
           assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
         end
 
+        test "unsafe javascript methods in helper calls with more than one level of nested hash and :dstr" do
+          errors = validate(<<-EOF).errors
+            <%= ui_my_helper(:foo, inner_html: { onclick: "foo \#{unsafe}" }) %>
+          EOF
+
+          assert_equal 1, errors.size
+          assert_equal "unsafe", errors.first.location.source
+          assert_equal "erb interpolation in javascript attribute must be wrapped in safe helper such as '(...).to_json'", errors.first.message
+        end
+
+        test "safe javascript methods in helper calls with more than one level of nested hash and :dstr" do
+          errors = validate(<<-EOF).errors
+            <%= ui_my_helper(:foo, inner_html: { onclick: "foo \#{unsafe.to_json}" }) %>
+          EOF
+
+          assert_equal 0, errors.size
+        end
+
         test "unsafe javascript methods in helper calls with string as key" do
           errors = validate(<<-EOF).errors
             <%= ui_my_helper(:foo, 'data-eval' => "alert(\#{unsafe})") %>


### PR DESCRIPTION
Covers more cases:

* Javascript attributes nested more than one level deep was previously not covered:
```ruby
form_tag(..., inner_html: { onclick: "..." })
```
* Javascript `data` attributes nested more than one level deep was previously not covered:
```ruby
form_tag(..., inner_html: { data: { eval: { "..." } })
```
* `raw` and `html_safe` used anywhere should be flagged as unsafe:
```ruby
<%= ui_my_helper(:foo, help_text: raw("foo")) %>
```