### PR TITLE
Support for right trim with =%>

### DIFF
--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -6,7 +6,7 @@ module BetterHtml
   module Tokenizer
     class BaseErb < ::Erubi::Engine
       REGEXP_WITHOUT_TRIM = /<%(={1,2}|%)?(.*?)()?%>([ \t]*\r?\n)?/m
-      STMT_TRIM_MATCHER = /\A(-|#)?(.*?)(-)?\z/m
+      STMT_TRIM_MATCHER = /\A(-|#)?(.*?)([-=])?\z/m
       EXPR_TRIM_MATCHER = /\A(.*?)(-)?\z/m
 
       attr_reader :tokens

--- a/test/better_html/tokenizer/html_erb_test.rb
+++ b/test/better_html/tokenizer/html_erb_test.rb
@@ -113,6 +113,16 @@ module BetterHtml
         assert_attributes ({ type: :text, loc: { line: 4, source: "after" } }), scanner.tokens[6]
       end
 
+      test "right trim with =%>" do
+        scanner = HtmlErb.new("<% trim =%>")
+        assert_equal 4, scanner.tokens.size
+
+        assert_attributes ({ type: :erb_begin, loc: { line: 1, source: '<%' } }), scanner.tokens[0]
+        assert_attributes ({ type: :code, loc: { line: 1, source: " trim " } }), scanner.tokens[1]
+        assert_attributes ({ type: :trim, loc: { line: 1, source: "=" } }), scanner.tokens[2]
+        assert_attributes ({ type: :erb_end, loc: { line: 1, source: "%>" } }), scanner.tokens[3]
+      end
+
       test "multi-line expression with trim" do
         scanner = HtmlErb.new("before\n<%= multi\nline -%>\nafter")
         assert_equal 8, scanner.tokens.size


### PR DESCRIPTION
According to the regex in erubi, right trim can be done with either `=%>` or `-%>`, either is valid:
https://github.com/jeremyevans/erubi/blob/ffe6fe4d1b22e9498580d7ba9a26491ee6ae5a6a/lib/erubi.rb#L73

This adds a test for this use case.

