### PR TITLE
Capture ERB tags in attributes list

### DIFF
--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -143,6 +143,8 @@ module BetterHtml
           attributes_tokens << build_attribute_node(tokens)
         elsif tokens.current.type == :attribute_quoted_value_start
           attributes_tokens << build_nameless_attribute_node(tokens)
+        elsif tokens.current.type == :erb_begin
+          attributes_tokens << build_erb_node(tokens)
         else
           # todo: warn about ignored things
           tokens.shift

--- a/lib/better_html/tree/attribute.rb
+++ b/lib/better_html/tree/attribute.rb
@@ -7,11 +7,15 @@ module BetterHtml
 
       def initialize(node)
         @node = node
-        @name_node, @equal_node, @value_node = *node
+        @name_node, @equal_node, @value_node = *node if @node.type == :attribute
       end
 
       def self.from_node(node)
         new(node)
+      end
+
+      def erb?
+        @node.type == :erb
       end
 
       def loc

--- a/lib/better_html/tree/tag.rb
+++ b/lib/better_html/tree/tag.rb
@@ -4,7 +4,7 @@ require 'better_html/ast/iterator'
 module BetterHtml
   module Tree
     class Tag
-      attr_reader :node
+      attr_reader :node, :start_solidus, :name_node, :attributes_node, :end_solidus
 
       def initialize(node)
         @node = node

--- a/test/better_html/parser_test.rb
+++ b/test/better_html/parser_test.rb
@@ -125,6 +125,29 @@ module BetterHtml
         )), tree.ast
     end
 
+    test "consume tag attributes with erb" do
+      tree = Parser.new("<div class=foo <%= erb %> name=bar>")
+      assert_equal s(:document,
+        s(:tag, nil,
+          s(:tag_name, "div"),
+          s(:tag_attributes,
+            s(:attribute,
+              s(:attribute_name, "class"),
+              s(:equal),
+              s(:attribute_value, "foo")
+            ),
+            s(:erb, s(:indicator, "="), nil,
+              s(:code, " erb "), nil),
+            s(:attribute,
+              s(:attribute_name, "name"),
+              s(:equal),
+              s(:attribute_value, "bar")
+            ),
+          ),
+          nil
+        )), tree.ast
+    end
+
     test "consume tag attributes nodes unquoted value" do
       tree = Parser.new("<div foo=bar>")
       assert_equal s(:document,


### PR DESCRIPTION
It's quite common to get an erb tag within the attributes list. This fixes an issue where the erb tag would be ignored completely by the parser.