### PR TITLE
Fix for <%%= syntax

### DIFF
--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -6,7 +6,7 @@ require 'parser/source/buffer'
 module BetterHtml
   module Tokenizer
     class BaseErb < ::Erubi::Engine
-      REGEXP_WITHOUT_TRIM = /<%(={1,2}|%)?(.*?)()?%>([ \t]*\r?\n)?/m
+      REGEXP_WITHOUT_TRIM = /<%(={1,2})?(.*?)()?%>([ \t]*\r?\n)?/m
       STMT_TRIM_MATCHER = /\A(-|#)?(.*?)([-=])?\z/m
       EXPR_TRIM_MATCHER = /\A(.*?)(-)?\z/m
 
@@ -28,11 +28,15 @@ module BetterHtml
       end
 
       def add_code(code)
-        _, ltrim_or_comment, code, rtrim = *STMT_TRIM_MATCHER.match(code)
-        ltrim = ltrim_or_comment if ltrim_or_comment == '-'
-        indicator = ltrim_or_comment if ltrim_or_comment == '#'
-        add_erb_tokens(ltrim, indicator, code, rtrim)
-        append("<%#{ltrim}#{indicator}#{code}#{rtrim}%>")
+        if code[0] == '%'
+          add_text("<%#{code}%>")
+        else
+          _, ltrim_or_comment, code, rtrim = *STMT_TRIM_MATCHER.match(code)
+          ltrim = ltrim_or_comment if ltrim_or_comment == '-'
+          indicator = ltrim_or_comment if ltrim_or_comment == '#'
+          add_erb_tokens(ltrim, indicator, code, rtrim)
+          append("<%#{ltrim}#{indicator}#{code}#{rtrim}%>")
+        end
       end
 
       def add_expression(indicator, code)

--- a/test/better_html/tokenizer/html_erb_test.rb
+++ b/test/better_html/tokenizer/html_erb_test.rb
@@ -150,6 +150,23 @@ module BetterHtml
         assert_attributes ({ type: :text, loc: { line: 3, source: "after" } }), scanner.tokens[6]
       end
 
+      test "escaped opening ERB tag <%%" do
+        scanner = HtmlErb.new(buffer("just some <%%= text %> no erb"))
+        assert_equal 11, scanner.tokens.size
+
+        assert_attributes ({ type: :text, loc: { line: 1, source: "just some " } }), scanner.tokens[0]
+        assert_attributes ({ type: :tag_start, loc: { line: 1, source: '<' } }), scanner.tokens[1]
+        assert_attributes ({ type: :tag_name, loc: { line: 1, source: '%%=' } }), scanner.tokens[2]
+        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[3]
+        assert_attributes ({ type: :attribute_name, loc: { line: 1, source: "text" } }), scanner.tokens[4]
+        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[5]
+        assert_attributes ({ type: :malformed, loc: { line: 1, source: "%>" } }), scanner.tokens[6]
+        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[7]
+        assert_attributes ({ type: :attribute_name, loc: { line: 1, source: "no" } }), scanner.tokens[8]
+        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[9]
+        assert_attributes ({ type: :attribute_name, loc: { line: 1, source: "erb" } }), scanner.tokens[10]
+      end
+
       private
 
       def assert_attributes(attributes, token)


### PR DESCRIPTION
Fix the case where `<%%=` gets output as text as `<%=`, this introduce a off by one in the token we emit.