### PR TITLE
Rescue `Parser::SyntaxError`

### DIFF
--- a/lib/better_html/test_helper/safe_erb/no_javascript_tag_helper.rb
+++ b/lib/better_html/test_helper/safe_erb/no_javascript_tag_helper.rb
@@ -17,7 +17,12 @@ module BetterHtml
             next if indicator == '#'
             source = code_node.loc.source
 
-            next unless (ruby_node = RubyNode.parse(source))
+            ruby_node = begin
+              RubyNode.parse(source)
+            rescue Parser::SyntaxError
+              nil
+            end
+            next unless ruby_node
             ruby_node.descendants(:send, :csend).each do |send_node|
               next unless send_node.method_name?(:javascript_tag)
 

--- a/lib/better_html/test_helper/safe_erb/script_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/script_interpolation.rb
@@ -28,7 +28,12 @@ module BetterHtml
             next if indicator == '#'
             source = code_node.loc.source
 
-            next unless (ruby_node = RubyNode.parse(source))
+            ruby_node = begin
+              RubyNode.parse(source)
+            rescue Parser::SyntaxError
+              nil
+            end
+            next unless ruby_node
             validate_script_interpolation(erb_node, ruby_node)
           end
         end

--- a/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
@@ -44,7 +44,12 @@ module BetterHtml
             source = code_node.loc.source
 
             if indicator == '='
-              if (ruby_node = RubyNode.parse(source))
+              ruby_node = begin
+                RubyNode.parse(source)
+              rescue Parser::SyntaxError
+                nil
+              end
+              if ruby_node
                 no_unsafe_calls(code_node, ruby_node)
                 unless ruby_node.static_return_value?
                   handle_missing_safe_wrapper(code_node, ruby_node, attribute.name)
@@ -65,7 +70,12 @@ module BetterHtml
             next if indicator == '#'
             source = code_node.loc.source
 
-            next unless (ruby_node = RubyNode.parse(source))
+            ruby_node = begin
+              RubyNode.parse(source)
+            rescue Parser::SyntaxError
+              nil
+            end
+            next unless ruby_node
             no_unsafe_calls(code_node, ruby_node)
             validate_ruby_helper(code_node, ruby_node)
           end


### PR DESCRIPTION
`RubyNode.parse` may raise, we need to rescue those errors because the partial ruby snippets that we parse in ERB may not be parseable.