### PR TITLE
Handle edge case where next_node is nil

### DIFF
--- a/lib/better_html/test_helper/safe_erb/base.rb
+++ b/lib/better_html/test_helper/safe_erb/base.rb
@@ -41,7 +41,7 @@ module BetterHtml
                 index = ast.to_a.find_index(tag_node)
                 next_node = ast.to_a[index + 1]
 
-                yielder.yield(tag, next_node.type == :text ? next_node : nil)
+                yielder.yield(tag, next_node&.type == :text ? next_node : nil)
               end
             end
           end


### PR DESCRIPTION
When the tag is the last thing in the file, `next_node` may be nil.