### PR TITLE
Treat <%%= as any other ERB tag

### DIFF
--- a/lib/better_html/test_helper/safe_erb/no_javascript_tag_helper.rb
+++ b/lib/better_html/test_helper/safe_erb/no_javascript_tag_helper.rb
@@ -14,7 +14,7 @@ module BetterHtml
         def no_javascript_tag_helper(node)
           erb_nodes(node).each do |erb_node, indicator_node, code_node|
             indicator = indicator_node&.loc&.source
-            next if indicator == '#'
+            next if indicator == '#' || indicator == '%'
             source = code_node.loc.source
 
             ruby_node = begin

--- a/lib/better_html/test_helper/safe_erb/script_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/script_interpolation.rb
@@ -25,7 +25,7 @@ module BetterHtml
           erb_nodes(node).each do |erb_node, indicator_node, code_node|
             next unless indicator_node.present?
             indicator = indicator_node.loc.source
-            next if indicator == '#'
+            next if indicator == '#' || indicator == '%'
             source = code_node.loc.source
 
             ruby_node = begin

--- a/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
+++ b/lib/better_html/test_helper/safe_erb/tag_interpolation.rb
@@ -67,7 +67,7 @@ module BetterHtml
         def validate_text_node(text_node)
           erb_nodes(text_node).each do |erb_node, indicator_node, code_node|
             indicator = indicator_node&.loc&.source
-            next if indicator == '#'
+            next if indicator == '#' || indicator == '%'
             source = code_node.loc.source
 
             ruby_node = begin

--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -29,7 +29,8 @@ module BetterHtml
 
       def add_code(code)
         if code[0] == '%'
-          add_text("<%#{code}%>")
+          add_erb_tokens(nil, '%', code[1..-1], nil)
+          append("<%#{code}%>")
         else
           _, ltrim_or_comment, code, rtrim = *STMT_TRIM_MATCHER.match(code)
           ltrim = ltrim_or_comment if ltrim_or_comment == '-'

--- a/test/better_html/tokenizer/html_erb_test.rb
+++ b/test/better_html/tokenizer/html_erb_test.rb
@@ -152,19 +152,14 @@ module BetterHtml
 
       test "escaped opening ERB tag <%%" do
         scanner = HtmlErb.new(buffer("just some <%%= text %> no erb"))
-        assert_equal 11, scanner.tokens.size
+        assert_equal 6, scanner.tokens.size
 
         assert_attributes ({ type: :text, loc: { line: 1, source: "just some " } }), scanner.tokens[0]
-        assert_attributes ({ type: :tag_start, loc: { line: 1, source: '<' } }), scanner.tokens[1]
-        assert_attributes ({ type: :tag_name, loc: { line: 1, source: '%%=' } }), scanner.tokens[2]
-        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[3]
-        assert_attributes ({ type: :attribute_name, loc: { line: 1, source: "text" } }), scanner.tokens[4]
-        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[5]
-        assert_attributes ({ type: :malformed, loc: { line: 1, source: "%>" } }), scanner.tokens[6]
-        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[7]
-        assert_attributes ({ type: :attribute_name, loc: { line: 1, source: "no" } }), scanner.tokens[8]
-        assert_attributes ({ type: :whitespace, loc: { line: 1, source: " " } }), scanner.tokens[9]
-        assert_attributes ({ type: :attribute_name, loc: { line: 1, source: "erb" } }), scanner.tokens[10]
+        assert_attributes ({ type: :erb_begin, loc: { line: 1, source: '<%' } }), scanner.tokens[1]
+        assert_attributes ({ type: :indicator, loc: { line: 1, source: "%" } }), scanner.tokens[2]
+        assert_attributes ({ type: :code, loc: { line: 1, source: "= text " } }), scanner.tokens[3]
+        assert_attributes ({ type: :erb_end, loc: { line: 1, source: "%>" } }), scanner.tokens[4]
+        assert_attributes ({ type: :text, loc: { line: 1, source: " no erb" } }), scanner.tokens[5]
       end
 
       private


### PR DESCRIPTION
Treating the inside of `<%%= ... %>` tags as text causes problem in various generators that output ERB. Instead I'll treat these as proper ERB tags with a different indicator (`%` as opposed to `=`), since that is what Erubi does anyway.