### PR TITLE
`AV::Handlers::ERB.escape_whitelist` is deprecated:

### DIFF
--- a/lib/better_html/better_erb.rb
+++ b/lib/better_html/better_erb.rb
@@ -57,9 +57,14 @@ class BetterHtml::BetterErb
       klass = BetterHtml::BetterErb.content_types[exts] unless excluded_template
       klass ||= self.class.erb_implementation
 
+      escape = if ActionView::VERSION::MAJOR <= 5
+        self.class.escape_whitelist.include?(template.type)
+      else
+        self.class.escape_ignore_list.include?(template.type)
+      end
       generator = klass.new(
         erb,
-        :escape => (self.class.escape_whitelist.include? template.type),
+        :escape => escape,
         :trim => (self.class.erb_trim_mode == "-")
       )
       generator.validate! if generator.respond_to?(:validate!)


### PR DESCRIPTION
`AV::Handlers::ERB.escape_whitelist` is deprecated:

- The replace is `escape_ignore_list`
- Ref https://github.com/rails/rails/commit/7c9751d7fe3aec1e67004d1bb5e4a1702fcacafb