### PR TITLE
Prevent evaluating file extension if the template is excluded

### DIFF
--- a/lib/better_html/better_erb.rb
+++ b/lib/better_html/better_erb.rb
@@ -40,9 +40,6 @@ class BetterHtml::BetterErb
       # expression
 
       source ||= template.source
-      filename = template.identifier.split("/").last
-      exts = filename.split(".")
-      exts = exts[1..exts.length].join(".")
       template_source = source.dup.force_encoding(Encoding::ASCII_8BIT)
 
       erb = template_source.gsub(ActionView::Template::Handlers::ERB::ENCODING_TAG, '')
@@ -54,7 +51,15 @@ class BetterHtml::BetterErb
       erb.encode!
 
       excluded_template = !!BetterHtml.config.template_exclusion_filter&.call(template.identifier)
-      klass = BetterHtml::BetterErb.content_types[exts] unless excluded_template
+
+      unless excluded_template
+        filename = template.identifier.split("/").last
+        exts = filename.split(".")
+        exts = exts[1..exts.length].join(".")
+
+        klass = BetterHtml::BetterErb.content_types[exts]
+      end
+
       klass ||= self.class.erb_implementation
 
       escape = if ActionView::VERSION::MAJOR <= 5


### PR DESCRIPTION
I am testing out a possible upcoming feature for Rails called [action_view components](https://github.com/github/actionview-component). They are an alternative to view partials.

When trying to use it in projects that include better-html, the code breaks when trying to figure out the file extension because the template identifier is an empty string.

This PR simply moves the evaluation of the file extension to after we checked if the template is excluded which solves the issue.

I'm not sure this is the right solution, but I also don't see any obvious harm in deferring the extension evaluation to that point in the code.