### PR TITLE
Allow application/ld+json as a script tag type

### DIFF
--- a/lib/better_html/test_helper/safe_erb/allowed_script_type.rb
+++ b/lib/better_html/test_helper/safe_erb/allowed_script_type.rb
@@ -4,7 +4,7 @@ module BetterHtml
   module TestHelper
     module SafeErb
       class AllowedScriptType < Base
-        VALID_JAVASCRIPT_TAG_TYPES = ['text/javascript', 'text/template', 'text/html']
+        VALID_JAVASCRIPT_TAG_TYPES = ['application/ld+json', 'text/javascript', 'text/template', 'text/html']
 
         def validate
           script_tags.each do |tag, _|


### PR DESCRIPTION
Google encourages site authors to present structured data to give
explicit clues about the meaning of content on the page. This change
adds the script type, `application/ld+json`, to the allowed script tag
types.

Page from Google's search docs:
https://developers.google.com/search/docs/guides/intro-structured-data

Example from the docs:

```
<script type="application/ld+json">
{
  "@context": "https://schema.org",
  "@type": "Organization",
  "url": "http://www.example.com",
  "name": "Unlimited Ball Bearings Corp.",
  "contactPoint": {
    "@type": "ContactPoint",
    "telephone": "+1-401-555-1212",
    "contactType": "Customer service"
  }
}
</script>
```