### PR TITLE
Require necessary files where they're needed

### DIFF
--- a/lib/better_html/test_helper/ruby_node.rb
+++ b/lib/better_html/test_helper/ruby_node.rb
@@ -1,3 +1,4 @@
+require 'better_html/parser'
 require 'parser/current'
 
 module BetterHtml

--- a/lib/better_html/test_helper/safe_lodash_tester.rb
+++ b/lib/better_html/test_helper/safe_lodash_tester.rb
@@ -1,6 +1,7 @@
 require 'better_html/test_helper/safety_error'
 require 'better_html/ast/iterator'
 require 'better_html/tree/tag'
+require 'better_html/parser'
 
 module BetterHtml
   module TestHelper

--- a/lib/better_html/tokenizer/html_lodash.rb
+++ b/lib/better_html/tokenizer/html_lodash.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'html_tokenizer'
 require_relative 'token'
 require_relative 'location'
 

--- a/test/better_html/test_helper/safe_erb/allowed_script_type_test.rb
+++ b/test/better_html/test_helper/safe_erb/allowed_script_type_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'better_html/parser'
 require 'better_html/test_helper/safe_erb/allowed_script_type'
 
 module BetterHtml

--- a/test/better_html/test_helper/safe_erb/no_statements_test.rb
+++ b/test/better_html/test_helper/safe_erb/no_statements_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'better_html/parser'
 require 'better_html/test_helper/safe_erb/no_statements'
 
 module BetterHtml

--- a/test/better_html/tokenizer/token_array_test.rb
+++ b/test/better_html/tokenizer/token_array_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'active_support/core_ext/array/access'
 require 'better_html/tokenizer/token'
 require 'better_html/tokenizer/location'
 require 'better_html/tokenizer/token_array'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 require "active_support"
 require "minitest/autorun"
 require 'better_html'
-require 'better_html/parser'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
I had an issue where requiring `better_html/test_helper/safe_lodash_tester` was not enough to pull all the required files, i.e.:

```ruby
require 'minitest/autorun'
require 'better_html'
require 'better_html/test_helper/safe_lodash_tester'

class SomeTest < Minitest::Test
  include BetterHtml::TestHelper::SafeLodashTester

  def test_foo
    assert_lodash_safety ""
  end
end
```

was failing with
```
NameError: uninitialized constant Parser
    ~/src/github.com/Shopify/better-html/lib/better_html/test_helper/safe_lodash_tester.rb:31:in `assert_lodash_safety'
```

So once I fixed that in the first commit, I looked at generalizing the fix for the rest of the gem in the second commit.
