### PR TITLE
Remove unused variables

### DIFF
--- a/lib/better_html/test_helper/safe_erb_tester.rb
+++ b/lib/better_html/test_helper/safe_erb_tester.rb
@@ -52,7 +52,7 @@ EOF
         end
 
         testers = tester_classes.map do |tester_klass|
-          tester = tester_klass.new(parser)
+          tester_klass.new(parser)
         end
         testers.each(&:validate)
         errors = testers.map(&:errors).flatten

--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -49,20 +49,20 @@ module BetterHtml
       def add_erb_tokens(ltrim, indicator, code, rtrim)
         pos = current_position
 
-        token = add_token(:erb_begin, pos, pos + 2)
+        add_token(:erb_begin, pos, pos + 2)
         pos += 2
 
         if ltrim
-          token = add_token(:trim, pos, pos + ltrim.length)
+          add_token(:trim, pos, pos + ltrim.length)
           pos += ltrim.length
         end
 
         if indicator
-          token = add_token(:indicator, pos, pos + indicator.length)
+          add_token(:indicator, pos, pos + indicator.length)
           pos += indicator.length
         end
 
-        token = add_token(:code, pos, pos + code.length)
+        add_token(:code, pos, pos + code.length)
         pos += code.length
 
         if rtrim
@@ -70,7 +70,7 @@ module BetterHtml
           pos += rtrim.length
         end
 
-        token = add_token(:erb_end, pos, pos + 2)
+        add_token(:erb_end, pos, pos + 2)
       end
 
       def add_token(type, begin_pos, end_pos)


### PR DESCRIPTION
👋 hello, friends!

In the latest release, I'm getting the following warnings when running the https://github.com/github/view_component test suite:

```
/Library/Ruby/Gems/2.6.0/gems/better_html-1.0.14/lib/better_html/test_helper/safe_erb_tester.rb:55: warning: assigned but unused variable - tester
/Library/Ruby/Gems/2.6.0/gems/better_html-1.0.14/lib/better_html/tokenizer/base_erb.rb:52: warning: assigned but unused variable - token
```

These warnings appear to be valid. The test suite does pass without these assignments.

It would be lovely if a release could be cut with these changes ❤️ Let me know if there's anything I can do to help!
