### PR TITLE
Use ** for the last argument to avoid ruby 2.7 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ approach to what ERB syntax is allowed given any HTML context. The next section
 describes the allowed syntax.
 
 Use ruby expressions inside quoted html attributes.
+
 ```erb
 Allowed ✅
 <img class="<%= value %>">
@@ -91,6 +92,7 @@ Not allowed ❌
 ```
 
 Use interpolation into tag or attribute names.
+
 ```erb
 Allowed ✅
 <img data-<%= value %>="true">
@@ -106,6 +108,7 @@ Not allowed ❌
 ```
 
 Insert conditional attributes using `html_attributes` helper.
+
 ```erb
 Allowed ✅
 <img <%= html_attributes(class: 'hidden') if condition? %>>
@@ -115,6 +118,7 @@ Not allowed ❌
 ```
 
 Only insert expressions (`<%=` or `<%==`) inside script tags, never statements (`<%`)
+
 ```erb
 <script>
   // Allowed ✅

--- a/lib/better_html/test_helper/safe_erb_tester.rb
+++ b/lib/better_html/test_helper/safe_erb_tester.rb
@@ -39,7 +39,7 @@ EOF
         options[:template_language] ||= :html
         buffer = ::Parser::Source::Buffer.new(options[:filename] || '(buffer)')
         buffer.source = data
-        parser = BetterHtml::Parser.new(buffer, options)
+        parser = BetterHtml::Parser.new(buffer, **options)
 
         tester_classes = [
           SafeErb::NoStatements,


### PR DESCRIPTION
Fixes #55 

There's only one place I could see that raises this warning in Ruby 2.7

See [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) for details on this change, and it is backwards compatible