### PR TITLE
Add metadata to gemspec to allow pushing to RubyGems.org

### DIFF
--- a/better_html.gemspec
+++ b/better_html.gemspec
@@ -14,6 +14,13 @@ Gem::Specification.new do |s|
   s.description = "Better HTML for Rails. Provides sane html helpers that make it easier to do the right thing."
   s.license     = "MIT"
 
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/Shopify/better-html/issues",
+    "changelog_uri" => "https://github.com/Shopify/better-html/releases",
+    "source_code_uri" => "https://github.com/Shopify/better-html/tree/v#{s.version}",
+    "allowed_push_host" => "https://rubygems.org"
+  }
+
   s.files = Dir["{app,config,db,lib,ext}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
My attempt to deploy v1.0.15 [failed](https://shipit.shopify.io/shopify/better-html/rubygems/deploys/993029) due to missing meta data

```
release-gem /app/data/stacks/shopify/better-html/rubygems/deploys/993029/better_html.gemspec
pid: 42764
Can't release the gem: spec.metadata['allowed_push_host'] must be defined.
release-gem /app/data/stacks/shopify/better-html/rubygems/deploys/993029/better_html.gemspec terminated with exit status 1
```

I think this is an additional check from shipit that blocks this being accidentally published externally, but we do want this to be external as it's published in [RubyGems](https://rubygems.org/gems/better_html)

At the same time, I figured I would add the bug tracker, changelog, and source uris to be a good citizen