### PR TITLE
Add missed errors class loading

### DIFF
--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -1,3 +1,4 @@
+require_relative 'errors'
 require_relative 'tokenizer/javascript_erb'
 require_relative 'tokenizer/html_erb'
 require_relative 'tokenizer/html_lodash'


### PR DESCRIPTION
On https://github.com/Shopify/erb-lint/blob/master/lib/erb_lint/linters/no_javascript_tag_helper.rb we have a loading of the better HTML, but errors have not been loaded before. So we got errors like:

```
 /builds/app/vendor/bundle-tools/gems/better_html-1.0.15/lib/better_html/parser.rb:13:in `<class:Parser>': uninitialized constant BetterHtml::Parser::HtmlError (NameError)
 Did you mean?  HtmlTokenizer
 	from /builds/app/vendor/bundle-tools/gems/better_html-1.0.15/lib/better_html/parser.rb:10:in `<module:BetterHtml>'
 	from /builds/app/vendor/bundle-tools/gems/better_html-1.0.15/lib/better_html/parser.rb:9:in `<top (required)>'
 	from /builds/app/vendor/bundle-tools/gems/better_html-1.0.15/lib/better_html/test_helper/ruby_node.rb:1:in `require'
 	from /builds/app/vendor/bundle-tools/gems/better_html-1.0.15/lib/better_html/test_helper/ruby_node.rb:1:in `<top (required)>'
from /builds/app/vendor/bundle-tools/gems/erb_lint-0.0.32/lib/erb_lint/linters/no_javascript_tag_helper.rb:4:in `require'
 	from /builds/app/vendor/bundle-tools/gems/erb_lint-0.0.32/lib/erb_lint/linters/no_javascript_tag_helper.rb:4:in `<top (required)>'
 	from /builds/app/vendor/bundle-tools/gems/erb_lint-0.0.32/lib/erb_lint.rb:16:in `require'
 	from /builds/app/vendor/bundle-tools/gems/erb_lint-0.0.32/lib/erb_lint.rb:16:in `block in <top (required)>'
 	from /builds/app/vendor/bundle-tools/gems/erb_lint-0.0.32/lib/erb_lint.rb:15:in `each'
```