### PR TITLE
Remove unreferenced variable, `token`

### DIFF
--- a/lib/better_html/tokenizer/base_erb.rb
+++ b/lib/better_html/tokenizer/base_erb.rb
@@ -66,7 +66,7 @@ module BetterHtml
         pos += code.length
 
         if rtrim
-          token = add_token(:trim, pos, pos + rtrim.length)
+          add_token(:trim, pos, pos + rtrim.length)
           pos += rtrim.length
         end
 


### PR DESCRIPTION
Continuing from d970295, there's another unused variable on :69 - it's possible that the Ruby interpreter got smarter at detecting this issue in more recent versions, this resolves a warning in my local machine.