### PR TITLE
test: fix test failing from a02c32c

### DIFF
--- a/test/better_html/test_helper/safe_erb/allowed_script_type_test.rb
+++ b/test/better_html/test_helper/safe_erb/allowed_script_type_test.rb
@@ -30,7 +30,9 @@ module BetterHtml
 
           assert_equal 1, errors.size
           assert_equal 'type="text/bogus"', errors.first.location.source
-          assert_equal "text/bogus is not a valid type, valid types are text/javascript, text/template, text/html", errors.first.message
+
+          expected_message = "text/bogus is not a valid type, valid types are #{BetterHtml::TestHelper::SafeErb::AllowedScriptType::VALID_JAVASCRIPT_TAG_TYPES.join(", ")}"
+          assert_equal expected_message, errors.first.message
         end
 
         private


### PR DESCRIPTION
Commit a02c32c introduced a new supported tag type but did not update the tests. This PR updates the test and gets us back to green.

Related to #54 