### PR TITLE
Add module as a type of <script>

### DIFF
--- a/lib/better_html/test_helper/safe_erb/allowed_script_type.rb
+++ b/lib/better_html/test_helper/safe_erb/allowed_script_type.rb
@@ -6,7 +6,7 @@ module BetterHtml
   module TestHelper
     module SafeErb
       class AllowedScriptType < Base
-        VALID_JAVASCRIPT_TAG_TYPES = ["application/ld+json", "text/javascript", "text/template", "text/html"]
+        VALID_JAVASCRIPT_TAG_TYPES = ["application/ld+json", "text/javascript", "text/template", "text/html", "module"]
 
         def validate
           script_tags.each do |tag, _|


### PR DESCRIPTION
Recently, JavaScript module would be getting used because almost all browsers support it, so `module` could also be added in `VALID_JAVASCRIPT_TAG_TYPES` as a [`type` of `<script>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type).

What do you think?