### PR TITLE
HtmlAttributes: result is html_safe

### DIFF
--- a/lib/better_html/html_attributes.rb
+++ b/lib/better_html/html_attributes.rb
@@ -24,7 +24,7 @@ module BetterHtml
           end
           "#{key}=\"#{escaped_value}\""
         end
-      end.join(" ")
+      end.join(" ").html_safe
     end
   end
 end


### PR DESCRIPTION
This makes the html_attributes helper safe to use even when it doesn't pass through BetterErb.  Without, the result isn't treated as HTML safe, and it gets escaped (again).