### PR TITLE
Print the filename if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ class ErbImplementationTest < ActiveSupport::TestCase
     pathname = Pathname.new(filename).relative_path_from(Rails.root)
     test "html errors in #{pathname}" do
       data = File.read(filename)
-      BetterHtml::BetterErb::ErubiImplementation.new(data).validate!
+      BetterHtml::BetterErb::ErubiImplementation.new(data, config: BetterHtml.config, filename:).validate!
     end
   end
 end
@@ -261,7 +261,9 @@ RSpec.describe "BetterHtml" do
 
     Dir[erb_glob].each do |filename|
       data = File.read(filename)
-      expect { BetterHtml::BetterErb::ErubiImplementation.new(data).validate! }.not_to raise_exception
+      expect {
+        BetterHtml::BetterErb::ErubiImplementation.new(data, config: BetterHtml.config, filename:).validate!
+      }.not_to raise_exception
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ class ErbImplementationTest < ActiveSupport::TestCase
     pathname = Pathname.new(filename).relative_path_from(Rails.root)
     test "html errors in #{pathname}" do
       data = File.read(filename)
-      BetterHtml::BetterErb::ErubiImplementation.new(data, config: BetterHtml.config, filename:).validate!
+      BetterHtml::BetterErb::ErubiImplementation.new(data, filename:).validate!
     end
   end
 end
@@ -262,7 +262,7 @@ RSpec.describe "BetterHtml" do
     Dir[erb_glob].each do |filename|
       data = File.read(filename)
       expect {
-        BetterHtml::BetterErb::ErubiImplementation.new(data, config: BetterHtml.config, filename:).validate!
+        BetterHtml::BetterErb::ErubiImplementation.new(data, filename:).validate!
       }.not_to raise_exception
     end
   end

--- a/lib/better_html/better_erb/runtime_checks.rb
+++ b/lib/better_html/better_erb/runtime_checks.rb
@@ -155,7 +155,7 @@ module BetterHtml
       end
 
       def build_location(line, column, length)
-        s = filename ? "In #{filename}\n" : ""
+        s = filename ? +"In #{filename}\n" : +""
         s << "On line #{line} column #{column}:\n"
         s << "#{extract_line(line)}\n"
         s << "#{" " * column}#{"^" * length}"

--- a/lib/better_html/better_erb/runtime_checks.rb
+++ b/lib/better_html/better_erb/runtime_checks.rb
@@ -155,7 +155,8 @@ module BetterHtml
       end
 
       def build_location(line, column, length)
-        s = +"On line #{line} column #{column}:\n"
+        s = filename ? "In #{filename}\n" : ""
+        s << "On line #{line} column #{column}:\n"
         s << "#{extract_line(line)}\n"
         s << "#{" " * column}#{"^" * length}"
       end


### PR DESCRIPTION
If you run `ErubiImplementation#validate!` (as described in the readme) and there's a validation error it will print the line number and column but not the filename. You can pass the filename to erubi (like this `BetterHtml::BetterErb::ErubiImplementation.new(data, config: BetterHtml.config, filename:).validate!`) but `ErubiImplementation` doesn't use that information in it's error message.

I've updated runtime checks so that if the filename is passed to `ErubiImplementation` it will be used in error messages, which can really help when fixing errors.