### PR TITLE
Use ruby_strdup with xfree

### DIFF
--- a/ext/better_html_ext/parser.c
+++ b/ext/better_html_ext/parser.c
@@ -1,4 +1,5 @@
 #include <ruby.h>
+#include <ruby/util.h>
 #include <ruby/encoding.h>
 #include "html_tokenizer.h"
 #include "parser.h"
@@ -81,7 +82,7 @@ static inline void parser_append_ref(struct token_reference_t *dest, struct toke
 static void parser_add_error(struct parser_t *parser, const char *message)
 {
   REALLOC_N(parser->errors, struct parser_document_error_t, parser->errors_count + 1);
-  parser->errors[parser->errors_count].message = strdup(message);
+  parser->errors[parser->errors_count].message = ruby_strdup(message);
   parser->errors[parser->errors_count].pos = parser->tk.scan.cursor;
   parser->errors[parser->errors_count].mb_pos = parser->tk.scan.mb_cursor;
   parser->errors[parser->errors_count].line_number = parser->doc.line_number;


### PR DESCRIPTION
`ruby_strdup` is like `strdup`, but using `xmalloc` which informs Ruby's GC about the allocation (confusingly by including `ruby/util.h` `strdup` is defined into `ruby_strdup`, but let's use `ruby_strdup` for clarity). We need to use this because we use `xfree` for the message in `parser_free`.

The issue this causes is pretty minimal in regular builds, it will artificially decrease `oldmalloc_increase_bytes`, but it's unlikely to be a significant amount. However getting this correct is important so that this extension can be used with debug builds.