### PR TITLE
Corrected how the railtie gets annotate_rendered_view_with_filenames

### DIFF
--- a/lib/better_html/railtie.rb
+++ b/lib/better_html/railtie.rb
@@ -4,12 +4,11 @@ require "better_html/better_erb"
 
 module BetterHtml
   class Railtie < Rails::Railtie
-    initializer "better_html.better_erb.initialization" do
+    initializer "better_html.better_erb.initialization" do |app|
       BetterHtml::BetterErb.prepend!
 
-      ActiveSupport.on_load(:action_view) do
-        BetterHtml.config.annotate_rendered_view_with_filenames = ActionView::Base.annotate_rendered_view_with_filenames
-      end
+      action_view_config = app.config.action_view
+      BetterHtml.config.annotate_rendered_view_with_filenames = action_view_config.annotate_rendered_view_with_filenames
     end
   end
 end


### PR DESCRIPTION
The way we were getting annotate_rendered_view_with_filenames from rails wasn't working (added in #122). I think this is due to loading order but it's hard to be sure because I can't actually see where rails initialises the value we were using.

I've changed it to get the config option directly from the rails config, which is hopefully a bit simpler and does not depend on any loading order.