### PR TITLE
Readme .yml config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or if you prefer storing the config elsewhere, in a yml file for example:
 
 ```ruby
 # config/initializers/better_html.rb
-BetterHtml.config = BetterHtml::Config.new(YAML.load(File.read('/path/to/.better-html.yml')))
+BetterHtml.config = BetterHtml::Config.new(YAML.unsafe_load_file('/path/to/.better-html.yml'))
 ```
 
 Available configuration options are:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or if you prefer storing the config elsewhere, in a yml file for example:
 
 ```ruby
 # config/initializers/better_html.rb
-BetterHtml.config = BetterHtml::Config.new(YAML.unsafe_load_file('/path/to/.better-html.yml'))
+BetterHtml.config = BetterHtml::Config.new(YAML.load_file(file_path, permitted_classes: [Regexp]))
 ```
 
 Available configuration options are:


### PR DESCRIPTION
Update the readme to use `YAML.unsafe_load` to parse regex values, `load` won't by default. I had the same issue as #106 , and this solved it. See [this psych discussion](https://github.com/ruby/psych/issues/489#issuecomment-841354484).

Note: .yml regex values must be in format `!ruby/regexp /\A[a-z0-9\-\:]+\z/` to be read as Regexp class. Not specific to this gem, but I can add a note below this if it is helpful.