### PR TITLE
Fix an error when parsing attribute without quotes and value

### DIFF
--- a/lib/better_html/parser.rb
+++ b/lib/better_html/parser.rb
@@ -191,7 +191,7 @@ module BetterHtml
         :attribute_unquoted_value,
       )
 
-      build_node(:attribute_value, children)
+      build_node(:attribute_value, children) if children.any?
     end
 
     def build_text_node(tokens)

--- a/test/better_html/parser_test.rb
+++ b/test/better_html/parser_test.rb
@@ -248,6 +248,37 @@ module BetterHtml
         tree.ast
     end
 
+    test "consumes tag attributes without value" do
+      tree = Parser.new(buffer("<div foo=>bar</div>"))
+      assert_equal s(
+        :document,
+        s(
+          :tag,
+          nil,
+          s(:tag_name, "div"),
+          s(
+            :tag_attributes,
+            s(
+              :attribute,
+              s(:attribute_name, "foo"),
+              s(:equal),
+              nil,
+            ),
+          ),
+          nil,
+        ),
+        s(:text, "bar"),
+        s(
+          :tag,
+          s(:solidus),
+          s(:tag_name, "div"),
+          nil,
+          nil,
+        ),
+      ),
+        tree.ast
+    end
+
     test "consume tag attributes nodes interpolation in name and value" do
       tree = Parser.new(buffer("<div data-<%= foo %>=\"some <%= value %> foo\">"))
       assert_equal s(


### PR DESCRIPTION
I stumbled across the following html snippet which crashes the parser: `<div foo=>bar</div>`. The interpreted html from browsers (both chrome and firefox) is `<div foo="">bar</div>` so the generated ast with the fix seems to make sense to me.

<details><summary>Error trace</summary>
<p>

```
/home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.2/lib/parser/source/range.rb:39:in `initialize': Parser::Source::Range: end_pos must not be less than begin_pos (ArgumentError)

          raise ArgumentError, 'Parser::Source::Range: end_pos must not be less than begin_pos'
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/tokenizer/location.rb:23:in `initialize'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:214:in `new'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:214:in `build_location'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:206:in `build_node'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:177:in `build_attribute_node'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:151:in `build_tag_attributes_node'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:133:in `build_tag_node'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:79:in `build_document_node'
        from /home/earlopain/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/better_html-2.1.1/lib/better_html/parser.rb:49:in `ast'
```

</p>
</details> 