### PR TITLE
Use Base64 to pass text through compiled erb templates

### DIFF
--- a/lib/better_html/better_erb/runtime_checks.rb
+++ b/lib/better_html/better_erb/runtime_checks.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "base64"
 require "action_view"
 
 module BetterHtml
@@ -32,7 +33,7 @@ module BetterHtml
       def add_expr_auto_escaped(src, code, auto_escape)
         flush_newline_if_pending(src)
 
-        escaped_code = escape_text(code)
+        escaped_code = Base64.urlsafe_encode64(code)
 
         src << "#{wrap_method}(@output_buffer, (#{parser_context.inspect}), '#{escaped_code}'.freeze, #{auto_escape})"
         method_name = "safe_#{@parser.context}_append"

--- a/lib/better_html/better_erb/validated_output_buffer.rb
+++ b/lib/better_html/better_erb/validated_output_buffer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "base64"
+
 module BetterHtml
   class BetterErb
     class ValidatedOutputBuffer
@@ -7,7 +9,7 @@ module BetterHtml
         def initialize(output, context, code, auto_escape)
           @output = output
           @context = context
-          @code = code
+          @code = Base64.urlsafe_decode64(code)
           @auto_escape = auto_escape
         end
 


### PR DESCRIPTION
This is a proposed way to potentially reduce confusion in the error highlighter in rails.

The problem is partly that the highlighter looks for the source erb expressions in the compiled template. I addressed this problem in https://github.com/rails/rails/pull/53657 by making the error highlighter more tolerant of this situation. It also occurs in rails easily, for example searching for a space between erb tags. Now the highlighter succeeds more often.

The other big problem is that multi-line blocks of code get double the newlines added to the compiled template. This causes the highlighter to fail to find the correct line in the first place and, until https://github.com/rails/rails/pull/53696 merges, this can cause the highlighter to crash completely.

I think the main reason for this is the duplication of the code in the template. For this I propose encoding the string version of the template with base64 (urlsafe doesn't add a newline that I have to trim). This keeps the string version of the code from visibly existing in the template.

Hopefully someone with more experience with better-html can validate this approach.