### PR TITLE
Drop support to unsupported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,11 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.3, 3.2, 3.1, '3.0']
+        ruby: [3.2, 3.3, 3.4]
         gemfile:
           - Gemfile
-          - gemfiles/Gemfile-rails-6-0
-          - gemfiles/Gemfile-rails-6-1
+          - gemfiles/Gemfile-rails-7-2
+          - gemfiles/Gemfile-rails-7-1
+          - gemfiles/Gemfile-rails-7-0
+        exclude:
+          - ruby: 3.4
+            gemfile: gemfiles/Gemfile-rails-7-0
+
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     better_html (2.1.1)
-      actionview (>= 6.0)
-      activesupport (>= 6.0)
+      actionview (>= 7.0)
+      activesupport (>= 7.0)
       ast (~> 2.0)
       erubi (~> 1.4)
       parser (>= 2.4)
@@ -166,7 +166,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionview
+  actionview (~> 8.0.0)
   better_html!
   minitest
   mocha
@@ -179,4 +179,4 @@ DEPENDENCIES
   ruby_memcheck
 
 BUNDLED WITH
-   2.6.2
+   2.6.3

--- a/better_html.gemspec
+++ b/better_html.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = "Better HTML for Rails. Provides sane html helpers that make it easier to do the right thing."
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 3.0.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/Shopify/better-html/issues",
@@ -29,8 +29,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,ext}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.require_paths = ["lib"]
 
-  s.add_dependency("actionview", ">= 6.0")
-  s.add_dependency("activesupport", ">= 6.0")
+  s.add_dependency("actionview", ">= 7.0")
+  s.add_dependency("activesupport", ">= 7.0")
   s.add_dependency("ast", "~> 2.0")
   s.add_dependency("erubi", "~> 1.4")
   s.add_dependency("parser", ">= 2.4")

--- a/gemfiles/Gemfile-rails-7-0
+++ b/gemfiles/Gemfile-rails-7-0
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "actionview", "~> 6.1.0"
+gem "actionview", "~> 7.0.0"
 gem "railties"
 gem "rake-compiler"
 gem "minitest"

--- a/gemfiles/Gemfile-rails-7-1
+++ b/gemfiles/Gemfile-rails-7-1
@@ -2,18 +2,17 @@
 
 source "https://rubygems.org"
 
-gemspec
+gemspec path: ".."
 
-gem "actionview", "~> 8.0.0"
+gem "actionview", "~> 7.1.0"
 gem "railties"
+gem "rake-compiler"
 gem "minitest"
 gem "mocha"
-gem "rake-compiler"
-gem "ostruct"
 gem "ruby_memcheck"
+gem "logger", "~> 1.6"
+gem "mutex_m", "~> 0.3"
 
 group :deployment, :test do
   gem "pry-byebug"
 end
-
-gem "rubocop-shopify"

--- a/gemfiles/Gemfile-rails-7-2
+++ b/gemfiles/Gemfile-rails-7-2
@@ -4,14 +4,12 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "actionview", "~> 6.0.0"
+gem "actionview", "~> 7.2.0"
 gem "railties"
 gem "rake-compiler"
 gem "minitest"
 gem "mocha"
 gem "ruby_memcheck"
-gem "logger", "~> 1.6"
-gem "mutex_m", "~> 0.3"
 
 group :deployment, :test do
   gem "pry-byebug"


### PR DESCRIPTION
- keep only supported versions

Rails >= 7.0
Ruby >= 3.2